### PR TITLE
NuGet package reverse dependency

### DIFF
--- a/src/NuGetTrends.Data/Migrations/20200320182545_ReverseDependency.Designer.cs
+++ b/src/NuGetTrends.Data/Migrations/20200320182545_ReverseDependency.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NuGetTrends.Data;
@@ -10,9 +11,10 @@ using NuGetTrends.Data;
 namespace NuGetTrends.Data.Migrations
 {
     [DbContext(typeof(NuGetTrendsContext))]
-    partial class NuGetTrendsContextModelSnapshot : ModelSnapshot
+    [Migration("20200320182545_ReverseDependency")]
+    partial class ReverseDependency
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/NuGetTrends.Data/Migrations/20200320182545_ReverseDependency.cs
+++ b/src/NuGetTrends.Data/Migrations/20200320182545_ReverseDependency.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace NuGetTrends.Data.Migrations
+{
+    public partial class ReverseDependency : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<bool>(
+                name: "is_prerelease",
+                table: "package_details_catalog_leafs",
+                nullable: false,
+                oldClrType: typeof(bool),
+                oldType: "boolean",
+                oldNullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "reverse_package_dependencies",
+                columns: table => new
+                {
+                    package_id = table.Column<string>(nullable: false),
+                    package_version = table.Column<string>(nullable: false),
+                    target_framework = table.Column<string>(nullable: false),
+                    dependency_package_id_lowered = table.Column<string>(nullable: false),
+                    dependency_range = table.Column<string>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_reverse_package_dependencies", x => new { x.target_framework, x.package_id, x.package_version, x.dependency_package_id_lowered, x.dependency_range });
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_reverse_package_dependencies_dependency_package_id_lowered",
+                table: "reverse_package_dependencies",
+                column: "dependency_package_id_lowered");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "reverse_package_dependencies");
+
+            migrationBuilder.AlterColumn<bool>(
+                name: "is_prerelease",
+                table: "package_details_catalog_leafs",
+                type: "boolean",
+                nullable: true,
+                oldClrType: typeof(bool));
+        }
+    }
+}

--- a/src/NuGetTrends.Data/ReversePackageDependency.cs
+++ b/src/NuGetTrends.Data/ReversePackageDependency.cs
@@ -1,0 +1,11 @@
+namespace NuGetTrends.Data
+{
+    public class ReversePackageDependency
+    {
+        public string PackageId { get; set; } = null!;
+        public string PackageVersion { get; set; } = null!;
+        public string TargetFramework { get; set; } = ""; // Old NuGet packages didn't specify TF. Empty string refers to that.
+        public string DependencyPackageIdLowered { get; set; } = null!;
+        public string DependencyRange { get; set; } = null!;
+    }
+}

--- a/src/NuGetTrends.Scheduler/CatalogLeafProcessor.cs
+++ b/src/NuGetTrends.Scheduler/CatalogLeafProcessor.cs
@@ -5,22 +5,21 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Npgsql;
 using NuGet.Protocol.Catalog;
 using NuGet.Protocol.Catalog.Models;
 using NuGetTrends.Data;
 
 namespace NuGetTrends.Scheduler
 {
-    public class CatalogLeafProcessor : ICatalogLeafProcessor
+    public abstract class CatalogLeafProcessor : ICatalogLeafProcessor
     {
         private readonly IServiceProvider _provider;
         private readonly ILogger<CatalogLeafProcessor> _logger;
-        private int _counter;
 
         private IServiceScope _scope;
-        private NuGetTrendsContext _context;
 
-        public CatalogLeafProcessor(
+        protected CatalogLeafProcessor(
                 IServiceProvider provider,
                 ILogger<CatalogLeafProcessor> logger)
         {
@@ -28,62 +27,28 @@ namespace NuGetTrends.Scheduler
             _logger = logger;
 
             _scope = _provider.CreateScope();
-            _context = _scope.ServiceProvider.GetRequiredService<NuGetTrendsContext>();
+            Context = _scope.ServiceProvider.GetRequiredService<NuGetTrendsContext>();
+            Context.ChangeTracker.AutoDetectChangesEnabled = false;
         }
 
-        private async Task Save(CancellationToken token)
+        protected NuGetTrendsContext Context { get; set; }
+
+        protected async Task Save(CancellationToken token)
         {
-            _counter++;
-
-            await _context.SaveChangesAsync(token);
-
-            if (_counter == 100) // recycle the DbContext
+            try
+            {
+                await Context.SaveChangesAsync(token);
+            }
+            finally
             {
                 _scope.Dispose();
                 _scope = _provider.CreateScope();
-                _context = _scope.ServiceProvider.GetRequiredService<NuGetTrendsContext>();
-                _counter = 0;
+                Context = _scope.ServiceProvider.GetRequiredService<NuGetTrendsContext>();
+                Context.ChangeTracker.AutoDetectChangesEnabled = false;
             }
         }
 
-        public async Task ProcessPackageDeleteAsync(PackageDeleteCatalogLeaf leaf, CancellationToken token)
-        {
-            var deletedItems = _context.PackageDetailsCatalogLeafs.Where(p =>
-                p.PackageId == leaf.PackageId && p.PackageVersion == leaf.PackageVersion);
-
-            var deleted = await deletedItems.ToListAsync(token);
-            if (deleted.Count == 0)
-            {
-                _logger.LogDebug("Deleted event but not found with: {Id}, {Version}", leaf.PackageId, leaf.PackageVersion);
-            }
-            else
-            {
-                if (deleted.Count > 1)
-                {
-                    _logger.LogError("Expected 1 item but found {count} for {id} and {version}.",
-                        deleted.Count,
-                        leaf.PackageId,
-                        leaf.PackageVersion);
-                }
-
-                foreach (var del in deleted)
-                {
-                    _context.PackageDetailsCatalogLeafs.Remove(del);
-                }
-                await Save(token);
-            }
-        }
-
-        public async Task ProcessPackageDetailsAsync(PackageDetailsCatalogLeaf leaf, CancellationToken token)
-        {
-            var exists = await _context.PackageDetailsCatalogLeafs.AnyAsync(
-                p => p.PackageId == leaf.PackageId && p.PackageVersion == leaf.PackageVersion, token);
-
-            if (!exists)
-            {
-                _context.PackageDetailsCatalogLeafs.Add(leaf);
-                await Save(token);
-            }
-        }
+        public abstract Task ProcessPackageDetailsAsync(PackageDetailsCatalogLeaf leaf, CancellationToken token);
+        public abstract Task ProcessPackageDeleteAsync(PackageDeleteCatalogLeaf leaf, CancellationToken token);
     }
 }

--- a/src/NuGetTrends.Scheduler/NuGetCatalogImporter.cs
+++ b/src/NuGetTrends.Scheduler/NuGetCatalogImporter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Hangfire;
@@ -12,18 +13,18 @@ namespace NuGetTrends.Scheduler
     {
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly CatalogCursorStore _cursorStore;
-        private readonly CatalogLeafProcessor _catalogLeafProcessor;
+        private readonly IEnumerable<ICatalogLeafProcessor> _catalogLeafProcessors;
         private readonly ILoggerFactory _loggerFactory;
 
         public NuGetCatalogImporter(
             IHttpClientFactory httpClientFactory,
             CatalogCursorStore cursorStore,
-            CatalogLeafProcessor catalogLeafProcessor,
+            IEnumerable<ICatalogLeafProcessor> catalogLeafProcessors,
             ILoggerFactory loggerFactory)
         {
             _httpClientFactory = httpClientFactory;
             _cursorStore = cursorStore;
-            _catalogLeafProcessor = catalogLeafProcessor;
+            _catalogLeafProcessors = catalogLeafProcessors;
             _loggerFactory = loggerFactory;
         }
 
@@ -44,7 +45,7 @@ namespace NuGetTrends.Scheduler
             var catalogProcessor = new CatalogProcessor(
                 _cursorStore,
                 catalogClient,
-                _catalogLeafProcessor,
+                _catalogLeafProcessors,
                 settings,
                 _loggerFactory.CreateLogger<CatalogProcessor>());
 

--- a/src/NuGetTrends.Scheduler/PackageDetailCatalogLeafProcessor.cs
+++ b/src/NuGetTrends.Scheduler/PackageDetailCatalogLeafProcessor.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NuGet.Protocol.Catalog.Models;
+
+namespace NuGetTrends.Scheduler
+{
+    public class PackageDetailCatalogLeafProcessor : CatalogLeafProcessor
+    {
+        private readonly ILogger<CatalogLeafProcessor> _logger;
+
+        public PackageDetailCatalogLeafProcessor(
+            IServiceProvider provider,
+            ILogger<CatalogLeafProcessor> logger)
+            : base(provider, logger)
+        {
+            _logger = logger;
+        }
+
+        public override async Task ProcessPackageDeleteAsync(PackageDeleteCatalogLeaf leaf, CancellationToken token)
+        {
+            var deletedItems = Context.PackageDetailsCatalogLeafs.Where(p =>
+                p.PackageId == leaf.PackageId && p.PackageVersion == leaf.PackageVersion);
+
+            var deleted = await deletedItems.ToListAsync(token);
+            if (deleted.Count == 0)
+            {
+                _logger.LogDebug("Deleted event but not found with: {Id}, {Version}", leaf.PackageId, leaf.PackageVersion);
+            }
+            else
+            {
+                if (deleted.Count > 1)
+                {
+                    _logger.LogError("Expected 1 item but found {count} for {id} and {version}.",
+                        deleted.Count,
+                        leaf.PackageId,
+                        leaf.PackageVersion);
+                }
+
+                foreach (var del in deleted)
+                {
+                    Context.PackageDetailsCatalogLeafs.Remove(del);
+                }
+                await Save(token);
+            }
+        }
+
+        public override async Task ProcessPackageDetailsAsync(PackageDetailsCatalogLeaf leaf, CancellationToken token)
+        {
+            var exists = await Context.PackageDetailsCatalogLeafs.AnyAsync(
+                p => p.PackageId == leaf.PackageId && p.PackageVersion == leaf.PackageVersion, token);
+
+            if (!exists)
+            {
+                Context.PackageDetailsCatalogLeafs.Add(leaf);
+                await Save(token);
+            }
+        }
+    }
+}

--- a/src/NuGetTrends.Scheduler/ReverseDependencyCatalogLeafProcessor.cs
+++ b/src/NuGetTrends.Scheduler/ReverseDependencyCatalogLeafProcessor.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+using NuGet.Protocol.Catalog.Models;
+using NuGetTrends.Data;
+
+namespace NuGetTrends.Scheduler
+{
+    public class ReverseDependencyCatalogLeafProcessor : CatalogLeafProcessor
+    {
+        private readonly ILogger<CatalogLeafProcessor> _logger;
+
+        public ReverseDependencyCatalogLeafProcessor(
+            IServiceProvider provider,
+            ILogger<CatalogLeafProcessor> logger)
+            : base(provider, logger) =>
+            _logger = logger;
+
+        public override Task ProcessPackageDeleteAsync(PackageDeleteCatalogLeaf leaf, CancellationToken token)
+            => Task.CompletedTask;
+
+        public override async Task ProcessPackageDetailsAsync(PackageDetailsCatalogLeaf leaf, CancellationToken token)
+        {
+            var dependencies = from dg in leaf.DependencyGroups
+                from d in dg.Dependencies
+                where d?.DependencyId is {} && d.Range is {}
+                select new ReversePackageDependency
+                {
+                    TargetFramework = dg.TargetFramework ?? string.Empty,
+                    PackageId = leaf.PackageId!,
+                    PackageVersion = leaf.PackageVersion!,
+                    DependencyPackageIdLowered = d.DependencyId!.ToLowerInvariant(),
+                    DependencyRange = d.Range!
+                };
+
+            try
+            {
+                Context.ReversePackageDependencies.AddRange(dependencies);
+                await Save(token);
+            }
+            catch (Exception e) when (
+                e is DbUpdateException && e.InnerException is PostgresException pex && pex.SqlState == "23505"
+                // TODO: Detach all entities as we add them? We don't need entity tracking here.
+                || e is InvalidOperationException && e.Message.StartsWith("The instance of entity type 'ReversePackageDependency' cannot be tracked because another instance with the key value"))
+            {
+                // Good news. We've got that in already...
+            }
+        }
+    }
+}

--- a/src/NuGetTrends.Scheduler/Startup.cs
+++ b/src/NuGetTrends.Scheduler/Startup.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
+using NuGet.Protocol.Catalog;
 using NuGetTrends.Data;
 using RabbitMQ.Client;
 using Sentry.Extensibility;
@@ -74,7 +75,8 @@ namespace NuGetTrends.Scheduler
             services.AddHttpClient("nuget"); // TODO: typed client? will be shared across all jobs
 
             services.AddScoped<CatalogCursorStore>();
-            services.AddScoped<CatalogLeafProcessor>();
+            services.AddScoped<ICatalogLeafProcessor, PackageDetailCatalogLeafProcessor>();
+            services.AddScoped<ICatalogLeafProcessor, ReverseDependencyCatalogLeafProcessor>();
             services.AddScoped<NuGetCatalogImporter>();
         }
 


### PR DESCRIPTION
Last day of vacation so a quick hack:

`http://localhost:5002/api/package/dependant/newtonsoft.json`

<img width="427" alt="image" src="https://user-images.githubusercontent.com/1633368/77213868-2e028f80-6aeb-11ea-9354-4469205bb7b7.png">

And:
Filter by Version range:

<img width="741" alt="image" src="https://user-images.githubusercontent.com/1633368/77213988-a49f8d00-6aeb-11ea-8ac3-a1ee5936f07f.png">


No range filter, but include version/target framework in result:

`http://localhost:5002/api/package/dependant/newtonsoft.json/version`

<img width="371" alt="image" src="https://user-images.githubusercontent.com/1633368/77213833-12978480-6aeb-11ea-9368-1b002785e3c2.png">

The 'filter by version range' evaluates in memory so likely will not work (OOM?) with all dataset for big packages.