### PR TITLE
Trim spaces on package search

### DIFF
--- a/src/NuGetTrends.Api/PackageController.cs
+++ b/src/NuGetTrends.Api/PackageController.cs
@@ -23,7 +23,7 @@ namespace NuGetTrends.Api
             => await _context.PackageDownloads
                 .AsNoTracking()
                 .Where(p => p.LatestDownloadCount != null
-                            && p.PackageIdLowered.Contains(q.ToLower(CultureInfo.InvariantCulture)))
+                            && p.PackageIdLowered.Contains(q.Trim().ToLower(CultureInfo.InvariantCulture)))
                 .OrderByDescending(p => p.LatestDownloadCount)
                 .Take(20)
                 .Select(p => new


### PR DESCRIPTION
…are.

This should avoid empty results when the search string has some whitespace at the beginning or the end, which often happens with copying the search string.

Helps with issue #63