### PR TITLE
propagate to nugt and nugettrends

### DIFF
--- a/src/NuGetTrends.Scheduler/DailyDownloadPackageIdPublisher.cs
+++ b/src/NuGetTrends.Scheduler/DailyDownloadPackageIdPublisher.cs
@@ -35,6 +35,7 @@ namespace NuGetTrends.Scheduler
 
         public async Task Import(IJobCancellationToken token)
         {
+            using var _ = _hub.PushScope();
             var transaction = _hub.StartTransaction("daily-download-pkg-id-publisher", "job",
                 "queues package ids to fetch download numbers");
             try

--- a/src/NuGetTrends.Scheduler/DailyDownloadPackageIdPublisher.cs
+++ b/src/NuGetTrends.Scheduler/DailyDownloadPackageIdPublisher.cs
@@ -69,12 +69,14 @@ namespace NuGetTrends.Scheduler
                     await conn.OpenAsync();
                     dbConnectSpan.Finish();
 
-                    var dbQuerySpan = queueIdsSpan.StartChild("db.query", "Connect to Postgres");
+                    var dbQuerySpan = queueIdsSpan.StartChild("db.query", "Query ids");
                     await using var cmd = new NpgsqlCommand("SELECT package_id FROM pending_packages_daily_downloads", (NpgsqlConnection)conn);
                     await using var reader = await cmd.ExecuteReaderAsync();
                     dbQuerySpan.Finish();
 
                     var batchSize = 25; // TODO: Configurable
+                    var processBatchSpan = queueIdsSpan.StartChild("db.read",
+                        $"Go through reader and queue in batches of {batchSize} ids");
                     var batch = new List<string>(batchSize);
                     while (await reader.ReadAsync())
                     {
@@ -88,14 +90,16 @@ namespace NuGetTrends.Scheduler
                             batch.Clear();
                         }
                     }
+                    processBatchSpan.Finish();
 
                     if (batch.Count != 0)
                     {
                         var queueSpan = queueIdsSpan.StartChild("queue.enqueue", "Enqueue incomplete batch.");
                         Queue(batch, channel, queueName, properties);
-                        queueSpan.Finish(SpanStatus.Ok);
+                        queueSpan.Finish();
                     }
 
+                    queueIdsSpan.SetTag("queue-name", queueName);
                     queueIdsSpan.SetTag("batch-size", batchSize.ToString());
                     queueIdsSpan.SetTag("message-count", messageCount.ToString());
                     queueIdsSpan.Finish();

--- a/src/NuGetTrends.Scheduler/NuGetCatalogImporter.cs
+++ b/src/NuGetTrends.Scheduler/NuGetCatalogImporter.cs
@@ -33,6 +33,7 @@ namespace NuGetTrends.Scheduler
 
         public async Task Import(IJobCancellationToken token)
         {
+            using var _ = _hub.PushScope();
             var transaction = _hub.StartTransaction("import-catalog", "Import nuget catalog");
             var logger = _loggerFactory.CreateLogger<NuGetCatalogImporter>();
 

--- a/src/NuGetTrends.Web/PackageController.cs
+++ b/src/NuGetTrends.Web/PackageController.cs
@@ -10,7 +10,7 @@ using NuGetTrends.Data;
 
 namespace NuGetTrends.Web
 {
-    [Route("api/[controller]")]
+    [Route("api/package")]
     [ApiController]
     public class PackageController : ControllerBase
     {

--- a/src/NuGetTrends.Web/Portal/src/app/app.module.ts
+++ b/src/NuGetTrends.Web/Portal/src/app/app.module.ts
@@ -20,7 +20,7 @@ Sentry.init({
   environment: environment.name,
   integrations: [
     new Integrations.BrowserTracing({
-      tracingOrigins: ['localhost', 'https://nugettrends.com/', 'https://nugettrends.com/api'],
+      tracingOrigins: ['localhost', /nugettrends|nugt/],
       routingInstrumentation: Sentry.routingInstrumentation,
     }),
   ],


### PR DESCRIPTION
Propagates the trace-id to any url with `nugt` or `nugettrends`.
This covers:
www.nugettrends.com
nugettrends.com
nugt.net (short urls)
and staging: stg.nugt.net