### PR TITLE
Fix not generating source maps

### DIFF
--- a/src/NuGetTrends.Web/Portal/angular.json
+++ b/src/NuGetTrends.Web/Portal/angular.json
@@ -45,7 +45,11 @@
             "vendorChunk": true,
             "extractLicenses": false,
             "buildOptimizer": false,
-            "sourceMap": true,
+            "sourceMap": {
+              "scripts": true,
+              "styles": false,
+              "vendor": false
+            },
             "optimization": false,
             "namedChunks": true
           },
@@ -59,11 +63,6 @@
               ],
               "optimization": true,
               "outputHashing": "all",
-              "sourceMap": {
-                "scripts": true,
-                "styles": false,
-                "vendor": false
-              },
               "namedChunks": false,
               "extractLicenses": true,
               "vendorChunk": false,
@@ -86,7 +85,6 @@
               "optimization": false,
               "vendorChunk": true,
               "extractLicenses": false,
-              "sourceMap": true,
               "namedChunks": true
             }
           },


### PR DESCRIPTION
Missed this during the upgrade. Now it generates them. 
![image](https://user-images.githubusercontent.com/5938087/118362740-05f8aa00-b591-11eb-998f-ca9609b32ea6.png)
