### PR TITLE
One compose to rule them all

### DIFF
--- a/.github/workflows/web-workflow.yml
+++ b/.github/workflows/web-workflow.yml
@@ -132,8 +132,8 @@ jobs:
         uses: docker/build-push-action@v2
         id: docker_build
         with:
-          context: ./src/NuGetTrends.Web
-          file: ./src/NuGetTrends.Web/Dockerfile
+          context: .
+          file: NuGetTrends.Web.dockerfile
           build-args: |
             ENVIRONMENT=${{ steps.docker-prep.outputs.environment }}
             VERSION=${{ steps.docker-prep.outputs.version }}

--- a/NuGetTrends.Web.Portal.dockerfile
+++ b/NuGetTrends.Web.Portal.dockerfile
@@ -1,0 +1,35 @@
+# ** Build
+
+FROM node:12 as build
+WORKDIR /app
+
+RUN npm install --global yarn
+
+COPY src/NuGetTrends.Web/Portal/package.json .
+COPY src/NuGetTrends.Web/Portal/yarn.lock .
+
+RUN yarn install
+
+COPY src/NuGetTrends.Web/Portal/tsconfig.json .
+COPY src/NuGetTrends.Web/Portal/tsconfig.app.json .
+COPY src/NuGetTrends.Web/Portal/tsconfig.spec.json .
+COPY src/NuGetTrends.Web/Portal/tslint.json .
+COPY src/NuGetTrends.Web/Portal/angular.json .
+COPY src/NuGetTrends.Web/Portal/e2e/ e2e/
+COPY src/NuGetTrends.Web/Portal/src/ src/
+
+RUN npm run build
+
+# ** Run
+
+FROM nginx:1.16.0 as run
+
+EXPOSE 80
+EXPOSE 443
+
+RUN rm /etc/nginx/conf.d/default.conf
+COPY src/NuGetTrends.Web/Portal/nginx/nginx.conf /etc/nginx/conf.d
+
+COPY --from=build /app/dist /usr/share/nginx/html
+
+ENTRYPOINT ["nginx", "-g", "daemon off;"]

--- a/NuGetTrends.Web.dockerfile
+++ b/NuGetTrends.Web.dockerfile
@@ -1,0 +1,28 @@
+# ** Build
+
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+WORKDIR /src
+
+COPY src/Directory.Build.props ./
+COPY src/NuGet.Protocol.Catalog NuGet.Protocol.Catalog
+COPY src/NuGetTrends.Data NuGetTrends.Data
+
+# Avoid copying /Portal
+COPY src/NuGetTrends.Web/Properties NuGetTrends.Web/Properties
+COPY src/NuGetTrends.Web/NuGetTrends.Web.csproj NuGetTrends.Web/NuGetTrends.Web.csproj
+COPY src/NuGetTrends.Web/*.cs NuGetTrends.Web/
+COPY src/NuGetTrends.Web/*.json NuGetTrends.Web/
+
+RUN dotnet publish NuGetTrends.Web -o NuGetTrends.Web/artifacts -c Release
+
+# ** Run
+
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS run
+WORKDIR /app
+
+EXPOSE 80
+EXPOSE 443
+
+COPY --from=build /src/NuGetTrends.Web/artifacts ./
+
+ENTRYPOINT ["dotnet", "NuGetTrends.Web.dll"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,5 +30,23 @@ services:
     ports:
       - "8080:80"
     restart: "no"
+  web:
+    build:
+      context: "."
+      dockerfile: "NuGetTrends.Web.dockerfile"
+    ports:
+      - "5000:80"
+    depends_on:
+      - "rabbitmq"
+      - "postgres"
+  portal:
+    build:
+      context: "."
+      dockerfile: "NuGetTrends.Web.Portal.dockerfile"
+    ports:
+      - "3000:80"
+    depends_on:
+      - "web"
+
 volumes:
   pgdata:

--- a/src/NuGetTrends.Web/Dockerfile
+++ b/src/NuGetTrends.Web/Dockerfile
@@ -1,5 +1,0 @@
-FROM mcr.microsoft.com/dotnet/aspnet:5.0
-COPY publish/ App/
-
-WORKDIR /App
-ENTRYPOINT ["dotnet", "NuGetTrends.Web.dll"]

--- a/src/NuGetTrends.Web/Portal/nginx/nginx.conf
+++ b/src/NuGetTrends.Web/Portal/nginx/nginx.conf
@@ -1,0 +1,17 @@
+server {
+
+    listen 80;
+
+    location / {
+        root /usr/share/nginx/html;
+        index index.html index.htm;
+        try_files $uri $uri/ /index.html;
+    }
+
+    error_page 500 502 503 504 /50x.html;
+
+    location = /50x.html {
+        root /usr/share/nginx/html;
+    }
+
+}


### PR DESCRIPTION
Moved dockerfiles to root because:
- NuGetTrends.Web depends on other projects outside of its own directory
- It's a bit cleaner this way

Also I noticed that the existing dockerfile in NuGetTrends.Web didn't actually build the project but merely copied the publish output produced by `dotnet`. This works for CI, but makes local development harder. So I integrated the build process inside the dockerfile.

Because `/Portal` is inside `/NuGetTrends.Web`, I did some naive filtering to avoid copying unnecessary files into the image. Long term this could be improved with a `dockerignore` file. Also, I would suggest to move the frontend project to a separate top level directory next to `/NuGetTrends.Web` and others.

Closes #147