### PR TITLE
ref/improve sentry integration

### DIFF
--- a/src/NuGet.Protocol.Catalog/NuGet.Protocol.Catalog.csproj
+++ b/src/NuGet.Protocol.Catalog/NuGet.Protocol.Catalog.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
     <PackageReference Include="NuGet.Protocol" Version="5.10.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Sentry" Version="3.9.0" />
   </ItemGroup>
 
 </Project>

--- a/src/NuGetTrends.Scheduler/DbUpdateExceptionProcessor.cs
+++ b/src/NuGetTrends.Scheduler/DbUpdateExceptionProcessor.cs
@@ -58,7 +58,15 @@ namespace NuGetTrends.Scheduler
                     }
                     if (postgres.Detail is { } detail)
                     {
-                        s.SetTag(nameof(postgres.Detail), detail);
+                            // Detail redacted as it may contain sensitive data. Specify 'Include Error Detail' in the connection string to include this information.
+                        if (detail.StartsWith("Detail redacted"))
+                        {
+                            s.SetTag(nameof(postgres.Detail), "redacted");
+                        }
+                        else
+                        {
+                            s.SetTag(nameof(postgres.Detail), detail);
+                        }
                     }
                 });
             }

--- a/src/NuGetTrends.Scheduler/NuGetTrends.Scheduler.csproj
+++ b/src/NuGetTrends.Scheduler/NuGetTrends.Scheduler.csproj
@@ -16,8 +16,8 @@
     <PackageReference Include="RabbitMQ.Client" Version="6.2.2" />
     <PackageReference Include="Hangfire.AspNetCore" Version="1.7.24" />
     <PackageReference Include="Hangfire.MemoryStorage" Version="1.7.0" />
-    <PackageReference Include="Sentry.AspNetCore" Version="3.8.3" />
-    <PackageReference Include="Sentry.Serilog" Version="3.8.3" />
+    <PackageReference Include="Sentry.AspNetCore" Version="3.9.0" />
+    <PackageReference Include="Sentry.Serilog" Version="3.9.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.2.0-dev-00272" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1-dev-00874" />

--- a/src/NuGetTrends.Scheduler/Program.cs
+++ b/src/NuGetTrends.Scheduler/Program.cs
@@ -62,6 +62,7 @@ namespace NuGetTrends.Scheduler
                         .UseSerilog()
                         .UseSentry(o =>
                         {
+                            o.AddExceptionFilterForType<OperationCanceledException>();
                             o.AddLogEntryFilter((category, level, eventId, exception)
                             => eventId.ToString() ==
                                "Microsoft.EntityFrameworkCore.Infrastructure.SensitiveDataLoggingEnabledWarning"

--- a/src/NuGetTrends.Scheduler/Startup.cs
+++ b/src/NuGetTrends.Scheduler/Startup.cs
@@ -8,7 +8,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
-using Npgsql.EntityFrameworkCore.PostgreSQL.Internal;
 using NuGetTrends.Data;
 using RabbitMQ.Client;
 using Sentry.Extensibility;

--- a/src/NuGetTrends.Scheduler/Startup.cs
+++ b/src/NuGetTrends.Scheduler/Startup.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Internal;
 using NuGetTrends.Data;
 using RabbitMQ.Client;
 using Sentry.Extensibility;

--- a/src/NuGetTrends.Scheduler/appsettings.Development.json
+++ b/src/NuGetTrends.Scheduler/appsettings.Development.json
@@ -2,8 +2,11 @@
   "Sentry": {
     "Dsn": "https://57331596a25b4c3da49750b292299e09@o179108.ingest.sentry.io/5936035"
   },
+  "DailyDownloadWorker": {
+    "WorkerCount": 1
+  },
   "ConnectionStrings": {
-    "NuGetTrends": "Host=localhost;Database=nugettrends;Username=postgres;Password=PUg2rt6Pp8Arx7Z9FbgJLFvxEL7pZ2"
+    "NuGetTrends": "Host=localhost;Database=nugettrends;Username=postgres;Password=PUg2rt6Pp8Arx7Z9FbgJLFvxEL7pZ2;Include Error Detail=true"
   },
   "RabbitMq": {
     "Hostname": "localhost",

--- a/src/NuGetTrends.Scheduler/appsettings.Development.json
+++ b/src/NuGetTrends.Scheduler/appsettings.Development.json
@@ -22,17 +22,16 @@
     },
     "WriteTo": [
       {
-        "Name": "Console",
-        "Args": {
-          "theme": "Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme::Code, Serilog.Sinks.Console"
-        }
-      },
-      {
         "Name": "Sentry",
         "Args": {
           "Dsn": "https://57331596a25b4c3da49750b292299e09@o179108.ingest.sentry.io/5936035",
-          "MinimumBreadcrumbLevel": "Debug",
           "MinimumEventLevel": "Warning"
+        }
+      },
+      {
+        "Name": "Console",
+        "Args": {
+          "theme": "Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme::Code, Serilog.Sinks.Console"
         }
       }
     ],

--- a/src/NuGetTrends.Scheduler/appsettings.Development.json
+++ b/src/NuGetTrends.Scheduler/appsettings.Development.json
@@ -1,4 +1,7 @@
 {
+  "Sentry": {
+    "Dsn": "https://57331596a25b4c3da49750b292299e09@o179108.ingest.sentry.io/5936035"
+  },
   "ConnectionStrings": {
     "NuGetTrends": "Host=localhost;Database=nugettrends;Username=postgres;Password=PUg2rt6Pp8Arx7Z9FbgJLFvxEL7pZ2"
   },
@@ -22,6 +25,14 @@
         "Name": "Console",
         "Args": {
           "theme": "Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme::Code, Serilog.Sinks.Console"
+        }
+      },
+      {
+        "Name": "Sentry",
+        "Args": {
+          "Dsn": "https://57331596a25b4c3da49750b292299e09@o179108.ingest.sentry.io/5936035",
+          "MinimumBreadcrumbLevel": "Debug",
+          "MinimumEventLevel": "Warning"
         }
       }
     ],

--- a/src/NuGetTrends.Scheduler/appsettings.Production.json
+++ b/src/NuGetTrends.Scheduler/appsettings.Production.json
@@ -10,27 +10,26 @@
         "Microsoft.EntityFrameworkCore.Query": "Debug",
         "Microsoft": "Warning",
         "System": "Warning",
-        "Sentry": "Information",
+        "Sentry": "Information"
       }
     },
     "WriteTo": [
       {
+        "Name": "Sentry",
+        "Args": {
+          "Dsn": "Set via env var: Serilog__WriteTo__0__Args__Dsn",
+          "DiagnosticLevel": "Info"
+        }
+      },
+      {
         "Name": "LogzIo",
         "Args": {
-          "authToken": "Set via env var: Serilog__WriteTo__0__Args__authToken",
+          "authToken": "Set via env var: Serilog__WriteTo__1__Args__authToken",
           "type": "worker-production",
           "useHttps": true,
           "boostProperties": true,
           "dataCenterSubDomain": "listener-eu",
           "restrictedToMinimumLevel": "Debug"
-        }
-      },
-      {
-        "Name": "Sentry",
-        "Args": {
-          "Dsn": "Set via env var: Serilog__WriteTo__1__Args__Dsn",
-          "MinimumBreadcrumbLevel": "Debug",
-          "MinimumEventLevel": "Warning"
         }
       }
     ],

--- a/src/NuGetTrends.Scheduler/appsettings.Production.json
+++ b/src/NuGetTrends.Scheduler/appsettings.Production.json
@@ -1,8 +1,6 @@
 {
   "Sentry": {
-    "Dsn": "", // Set via env var
-    "AttachStackTrace": true, // Send stack trace of log messages (without exception)
-    "Debug": true,
+    "Dsn": "Set via env var Sentry__Dsn",
     "DiagnosticLevel": "Info"
   },
   "Serilog": {

--- a/src/NuGetTrends.Scheduler/appsettings.Staging.json
+++ b/src/NuGetTrends.Scheduler/appsettings.Staging.json
@@ -1,9 +1,6 @@
 {
   "Sentry": {
-    "Dsn": "", // Set via env var
-    "AttachStackTrace": true, // Send stack trace of log messages (without exception)
-    "Debug": true,
-    "DiagnosticLevel": "Info"
+    "Dsn": "Set via env var Sentry__Dsn"
   },
   "Serilog": {
     "MinimumLevel": {
@@ -31,8 +28,7 @@
         "Name": "Sentry",
         "Args": {
           "Dsn": "Set via env var: Serilog__WriteTo__1__Args__Dsn",
-          "MinimumBreadcrumbLevel": "Debug",
-          "MinimumEventLevel": "Warning"
+          "MinimumBreadcrumbLevel": "Debug"
         }
       },
       {

--- a/src/NuGetTrends.Scheduler/appsettings.Staging.json
+++ b/src/NuGetTrends.Scheduler/appsettings.Staging.json
@@ -14,21 +14,20 @@
     },
     "WriteTo": [
       {
+        "Name": "Sentry",
+        "Args": {
+          "Dsn": "Set via env var: Serilog__WriteTo__0__Args__Dsn"
+        }
+      },
+      {
         "Name": "LogzIo",
         "Args": {
-          "authToken": "Set via env var: Serilog__WriteTo__0__Args__authToken",
+          "authToken": "Set via env var: Serilog__WriteTo__1__Args__authToken",
           "type": "worker-staging",
           "useHttps": true,
           "boostProperties": true,
           "dataCenterSubDomain": "listener-eu",
           "restrictedToMinimumLevel": "Debug"
-        }
-      },
-      {
-        "Name": "Sentry",
-        "Args": {
-          "Dsn": "Set via env var: Serilog__WriteTo__1__Args__Dsn",
-          "MinimumBreadcrumbLevel": "Debug"
         }
       },
       {

--- a/src/NuGetTrends.Scheduler/appsettings.json
+++ b/src/NuGetTrends.Scheduler/appsettings.json
@@ -7,6 +7,8 @@
     "WorkerCount": 8
   },
   "Sentry": {
-    "TracesSampleRate": 1.0
+    "TracesSampleRate": 1.0,
+    "Debug": true,
+    "AttachStackTrace": true
   }
 }

--- a/src/NuGetTrends.Scheduler/appsettings.json
+++ b/src/NuGetTrends.Scheduler/appsettings.json
@@ -10,5 +10,16 @@
     "TracesSampleRate": 1.0,
     "Debug": true,
     "AttachStackTrace": true
+  },
+  "Serilog": {
+    "WriteTo": [
+      {
+        "Name": "Sentry",
+        "Args": {
+          "Debug": true,
+          "MinimumBreadcrumbLevel": "Debug"
+        }
+      }
+    ]
   }
 }

--- a/src/NuGetTrends.Scheduler/appsettings.json
+++ b/src/NuGetTrends.Scheduler/appsettings.json
@@ -8,8 +8,7 @@
   },
   "Sentry": {
     "TracesSampleRate": 1.0,
-    "Debug": true,
-    "AttachStackTrace": true
+    "Debug": true
   },
   "Serilog": {
     "WriteTo": [

--- a/src/NuGetTrends.Web/NuGetTrends.Web.csproj
+++ b/src/NuGetTrends.Web/NuGetTrends.Web.csproj
@@ -13,9 +13,9 @@
     <PackageReference Include="Shortr.AspNetCore" Version="1.0.0-beta01" />
     <PackageReference Include="Shortr.Npgsql" Version="1.0.0-beta01" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.1" />
-    <PackageReference Include="Sentry.Tunnel" Version="3.8.3" />
-    <PackageReference Include="Sentry.AspNetCore" Version="3.8.3" />
-    <PackageReference Include="Sentry.Serilog" Version="3.8.3" />
+    <PackageReference Include="Sentry.Tunnel" Version="3.9.0" />
+    <PackageReference Include="Sentry.AspNetCore" Version="3.9.0" />
+    <PackageReference Include="Sentry.Serilog" Version="3.9.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.2.0-dev-00272" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1-dev-00874" />

--- a/src/NuGetTrends.Web/Program.cs
+++ b/src/NuGetTrends.Web/Program.cs
@@ -36,9 +36,7 @@ namespace NuGetTrends.Web
             {
                 Log.Information("Starting.");
 
-                SentrySdk.CaptureMessage("Works");
-                // throw new Exception("Test!");
-                // CreateHostBuilder(args).Build().Run();
+                CreateHostBuilder(args).Build().Run();
 
                 return 0;
             }

--- a/src/NuGetTrends.Web/Program.cs
+++ b/src/NuGetTrends.Web/Program.cs
@@ -58,7 +58,7 @@ namespace NuGetTrends.Web
                     webBuilder
                         .UseConfiguration(Configuration)
                         .UseSerilog()
-                        .UseSentry()
+                        .UseSentry(o => o.AddExceptionFilterForType<OperationCanceledException>())
                         .UseStartup<Startup>();
                 });
     }

--- a/src/NuGetTrends.Web/Program.cs
+++ b/src/NuGetTrends.Web/Program.cs
@@ -36,7 +36,9 @@ namespace NuGetTrends.Web
             {
                 Log.Information("Starting.");
 
-                CreateHostBuilder(args).Build().Run();
+                SentrySdk.CaptureMessage("Works");
+                // throw new Exception("Test!");
+                // CreateHostBuilder(args).Build().Run();
 
                 return 0;
             }
@@ -58,11 +60,7 @@ namespace NuGetTrends.Web
                     webBuilder
                         .UseConfiguration(Configuration)
                         .UseSerilog()
-                        .UseSentry(s =>
-                        {
-                            s.AddInAppExclude("Npgsql");
-                            s.AddInAppExclude("Serilog");
-                        })
+                        .UseSentry()
                         .UseStartup<Startup>();
                 });
     }

--- a/src/NuGetTrends.Web/appsettings.Development.json
+++ b/src/NuGetTrends.Web/appsettings.Development.json
@@ -1,4 +1,7 @@
 {
+  "Sentry": {
+    "Dsn": "https://57331596a25b4c3da49750b292299e09@o179108.ingest.sentry.io/5936035"
+  },
   "ConnectionStrings": {
     "NuGetTrends": "Host=localhost;Database=nugettrends;Username=postgres;Password=PUg2rt6Pp8Arx7Z9FbgJLFvxEL7pZ2"
   },
@@ -24,11 +27,16 @@
         "Args": {
           "theme": "Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme::Code, Serilog.Sinks.Console"
         }
+      },
+      {
+        "Name": "Sentry",
+        "Args": {
+          "Dsn": "https://57331596a25b4c3da49750b292299e09@o179108.ingest.sentry.io/5936035",
+          "MinimumBreadcrumbLevel": "Debug",
+          "MinimumEventLevel": "Warning"
+        }
       }
     ],
-    "Enrich": [
-      "FromLogContext",
-      "WithMachineName"
-    ]
+    "Enrich": [ "FromLogContext", "WithMachineName" ]
   }
 }

--- a/src/NuGetTrends.Web/appsettings.Development.json
+++ b/src/NuGetTrends.Web/appsettings.Development.json
@@ -23,17 +23,16 @@
     },
     "WriteTo": [
       {
-        "Name": "Console",
-        "Args": {
-          "theme": "Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme::Code, Serilog.Sinks.Console"
-        }
-      },
-      {
         "Name": "Sentry",
         "Args": {
           "Dsn": "https://57331596a25b4c3da49750b292299e09@o179108.ingest.sentry.io/5936035",
-          "MinimumBreadcrumbLevel": "Debug",
           "MinimumEventLevel": "Warning"
+        }
+      },
+      {
+        "Name": "Console",
+        "Args": {
+          "theme": "Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme::Code, Serilog.Sinks.Console"
         }
       }
     ],

--- a/src/NuGetTrends.Web/appsettings.Development.json
+++ b/src/NuGetTrends.Web/appsettings.Development.json
@@ -3,7 +3,7 @@
     "Dsn": "https://57331596a25b4c3da49750b292299e09@o179108.ingest.sentry.io/5936035"
   },
   "ConnectionStrings": {
-    "NuGetTrends": "Host=localhost;Database=nugettrends;Username=postgres;Password=PUg2rt6Pp8Arx7Z9FbgJLFvxEL7pZ2"
+    "NuGetTrends": "Host=localhost;Database=nugettrends;Username=postgres;Password=PUg2rt6Pp8Arx7Z9FbgJLFvxEL7pZ2;Include Error Detail=true",
   },
   "Shortr": {
     "DestinationWhiteListedBaseAddresses": [

--- a/src/NuGetTrends.Web/appsettings.Production.json
+++ b/src/NuGetTrends.Web/appsettings.Production.json
@@ -1,8 +1,6 @@
 {
   "Sentry": {
-    "Dsn": "", // Set via env var
-    "AttachStackTrace": true, // Send stack trace of log messages (without exception)
-    "Debug": true,
+    "Dsn": "Set via env var Sentry__Dsn",
     "DiagnosticLevel": "Info"
   },
   "Serilog": {
@@ -29,8 +27,9 @@
       {
         "Name": "Sentry",
         "Args": {
-          "MinimumBreadcrumbLevel": "Debug",
-          "MinimumEventLevel": "Warning"
+          "Dsn": "Set via env var: Serilog__WriteTo__1__Args__Dsn",
+          "DiagnosticLevel": "Info",
+          "MinimumBreadcrumbLevel": "Debug"
         }
       }
     ],

--- a/src/NuGetTrends.Web/appsettings.Production.json
+++ b/src/NuGetTrends.Web/appsettings.Production.json
@@ -14,22 +14,21 @@
     },
     "WriteTo": [
       {
+        "Name": "Sentry",
+        "Args": {
+          "Dsn": "Set via env var: Serilog__WriteTo__0__Args__Dsn",
+          "DiagnosticLevel": "Info"
+        }
+      },
+      {
         "Name": "LogzIo",
         "Args": {
-          "authToken": "Set via env var: Serilog__WriteTo__0__Args__authToken",
+          "authToken": "Set via env var: Serilog__WriteTo__1__Args__authToken",
           "type": "api-production",
           "useHttps": true,
           "boostProperties": true,
           "dataCenterSubDomain": "listener-eu",
           "restrictedToMinimumLevel": "Debug"
-        }
-      },
-      {
-        "Name": "Sentry",
-        "Args": {
-          "Dsn": "Set via env var: Serilog__WriteTo__1__Args__Dsn",
-          "DiagnosticLevel": "Info",
-          "MinimumBreadcrumbLevel": "Debug"
         }
       }
     ],

--- a/src/NuGetTrends.Web/appsettings.Staging.json
+++ b/src/NuGetTrends.Web/appsettings.Staging.json
@@ -1,9 +1,6 @@
 {
   "Sentry": {
-    "Dsn": "", // Set via env var
-    "AttachStackTrace": true, // Send stack trace of log messages (without exception)
-    "Debug": true,
-    "DiagnosticLevel": "Info"
+    "Dsn": "Set via env var Sentry__Dsn"
   },
   "Serilog": {
     "MinimumLevel": {
@@ -29,8 +26,8 @@
       {
         "Name": "Sentry",
         "Args": {
-          "MinimumBreadcrumbLevel": "Debug",
-          "MinimumEventLevel": "Warning"
+          "Dsn": "Set via env var: Serilog__WriteTo__1__Args__Dsn",
+          "MinimumBreadcrumbLevel": "Debug"
         }
       },
       {

--- a/src/NuGetTrends.Web/appsettings.Staging.json
+++ b/src/NuGetTrends.Web/appsettings.Staging.json
@@ -13,21 +13,20 @@
     },
     "WriteTo": [
       {
+        "Name": "Sentry",
+        "Args": {
+          "Dsn": "Set via env var: Serilog__WriteTo__0__Args__Dsn"
+        }
+      },
+      {
         "Name": "LogzIo",
         "Args": {
-          "authToken": "Set via env var: Serilog__WriteTo__0__Args__authToken",
+          "authToken": "Set via env var: Serilog__WriteTo__1__Args__authToken",
           "type": "api-staging",
           "useHttps": true,
           "boostProperties": true,
           "dataCenterSubDomain": "listener-eu",
           "restrictedToMinimumLevel": "Debug"
-        }
-      },
-      {
-        "Name": "Sentry",
-        "Args": {
-          "Dsn": "Set via env var: Serilog__WriteTo__1__Args__Dsn",
-          "MinimumBreadcrumbLevel": "Debug"
         }
       },
       {

--- a/src/NuGetTrends.Web/appsettings.json
+++ b/src/NuGetTrends.Web/appsettings.json
@@ -7,6 +7,8 @@
     ]
   },
   "Sentry": {
-    "TracesSampleRate": 1.0
+    "TracesSampleRate": 1.0,
+    "Debug": true,
+    "AttachStackTrace": true
   }
 }

--- a/src/NuGetTrends.Web/appsettings.json
+++ b/src/NuGetTrends.Web/appsettings.json
@@ -10,5 +10,16 @@
     "TracesSampleRate": 1.0,
     "Debug": true,
     "AttachStackTrace": true
+  },
+  "Serilog": {
+    "WriteTo": [
+      {
+        "Name": "Sentry",
+        "Args": {
+          "Debug": true,
+          "MinimumBreadcrumbLevel": "Debug"
+        }
+      }
+    ]
   }
 }

--- a/src/NuGetTrends.Web/appsettings.json
+++ b/src/NuGetTrends.Web/appsettings.json
@@ -8,8 +8,7 @@
   },
   "Sentry": {
     "TracesSampleRate": 1.0,
-    "Debug": true,
-    "AttachStackTrace": true
+    "Debug": true
   },
   "Serilog": {
     "WriteTo": [


### PR DESCRIPTION
- bump 3.9.0 enable in develop
- capture crashes on startup
- db spans

Now we can see how much time we spend compiling queries and running them within transactions:

![image](https://user-images.githubusercontent.com/1633368/131257686-68307e1a-740a-472e-828b-4215f061c2bd.png)
