### PR TITLE
Bump Sentry version

### DIFF
--- a/src/NuGet.Protocol.Catalog/NuGet.Protocol.Catalog.csproj
+++ b/src/NuGet.Protocol.Catalog/NuGet.Protocol.Catalog.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
     <PackageReference Include="NuGet.Protocol" Version="5.10.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Sentry" Version="3.9.0" />
+    <PackageReference Include="Sentry" Version="3.11.0" />
   </ItemGroup>
 
 </Project>

--- a/src/NuGetTrends.Scheduler/NuGetTrends.Scheduler.csproj
+++ b/src/NuGetTrends.Scheduler/NuGetTrends.Scheduler.csproj
@@ -16,8 +16,8 @@
     <PackageReference Include="RabbitMQ.Client" Version="6.2.2" />
     <PackageReference Include="Hangfire.AspNetCore" Version="1.7.24" />
     <PackageReference Include="Hangfire.MemoryStorage" Version="1.7.0" />
-    <PackageReference Include="Sentry.AspNetCore" Version="3.9.0" />
-    <PackageReference Include="Sentry.Serilog" Version="3.9.0" />
+    <PackageReference Include="Sentry.AspNetCore" Version="3.11.0" />
+    <PackageReference Include="Sentry.Serilog" Version="3.11.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.2.0-dev-00272" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1-dev-00874" />

--- a/src/NuGetTrends.Web/NuGetTrends.Web.csproj
+++ b/src/NuGetTrends.Web/NuGetTrends.Web.csproj
@@ -13,9 +13,9 @@
     <PackageReference Include="Shortr.AspNetCore" Version="1.0.0-beta01" />
     <PackageReference Include="Shortr.Npgsql" Version="1.0.0-beta01" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.1" />
-    <PackageReference Include="Sentry.Tunnel" Version="3.9.0" />
-    <PackageReference Include="Sentry.AspNetCore" Version="3.9.0" />
-    <PackageReference Include="Sentry.Serilog" Version="3.9.0" />
+    <PackageReference Include="Sentry.Tunnel" Version="3.11.0" />
+    <PackageReference Include="Sentry.AspNetCore" Version="3.11.0" />
+    <PackageReference Include="Sentry.Serilog" Version="3.11.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.2.0-dev-00272" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1-dev-00874" />


### PR DESCRIPTION
This PR updates Sentry dependencies from 3.9.0 to 3.11.0, adding better performance monitoring updates.