### PR TITLE
Generate release version for Sentry from Git hash

### DIFF
--- a/src/NuGetTrends.Web/Portal/angular.json
+++ b/src/NuGetTrends.Web/Portal/angular.json
@@ -38,7 +38,9 @@
               "src/colors.scss",
               "src/styles.scss"
             ],
-            "scripts": [],
+            "scripts": [
+              "tmp/release.js"
+            ],
             "allowedCommonJsDependencies": [
               "chart.js"
             ],

--- a/src/NuGetTrends.Web/Portal/package.json
+++ b/src/NuGetTrends.Web/Portal/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build",
+    "build": "npm run generate-release && ng build",
+    "generate-release": "mkdir -p tmp; echo window.SENTRY_RELEASE={id:\\'`git rev-parse --short HEAD`\\'} > tmp/release.js",
     "test-no-watch": "ng test --watch=false",
     "lint": "ng lint",
     "test-cc": "ng test --watch=false --code-coverage",


### PR DESCRIPTION
Performed only during production build, as there is no point in using different releases for development.