### PR TITLE
flush transaction

### DIFF
--- a/src/NuGetTrends.Scheduler/NuGetCatalogImporter.cs
+++ b/src/NuGetTrends.Scheduler/NuGetCatalogImporter.cs
@@ -64,7 +64,7 @@ namespace NuGetTrends.Scheduler
             catch (Exception e)
             {
                 transaction.Finish(e);
-                await SentrySdk.CaptureException(e);
+                SentrySdk.CaptureException(e);
                 throw;
             }
             finally

--- a/src/NuGetTrends.Scheduler/NuGetCatalogImporter.cs
+++ b/src/NuGetTrends.Scheduler/NuGetCatalogImporter.cs
@@ -64,6 +64,7 @@ namespace NuGetTrends.Scheduler
             catch (Exception e)
             {
                 transaction.Finish(e);
+                await SentrySdk.CaptureException(e);
                 throw;
             }
             finally

--- a/src/NuGetTrends.Scheduler/NuGetCatalogImporter.cs
+++ b/src/NuGetTrends.Scheduler/NuGetCatalogImporter.cs
@@ -66,6 +66,10 @@ namespace NuGetTrends.Scheduler
                 transaction.Finish(e);
                 throw;
             }
+            finally
+            {
+                await SentrySdk.FlushAsync(TimeSpan.FromSeconds(2));
+            }
         }
     }
 }


### PR DESCRIPTION
There's a scope pushed at the top, so before disposing it, make sure transaction is flushed out.