### PR TITLE
Require Sentry release only in Angular prod build

### DIFF
--- a/src/NuGetTrends.Web/Portal/angular.json
+++ b/src/NuGetTrends.Web/Portal/angular.json
@@ -38,9 +38,6 @@
               "src/colors.scss",
               "src/styles.scss"
             ],
-            "scripts": [
-              "tmp/release.js"
-            ],
             "allowedCommonJsDependencies": [
               "chart.js"
             ],
@@ -80,6 +77,9 @@
                   "maximumWarning": "6kb",
                   "maximumError": "10kb"
                 }
+              ],
+              "scripts": [
+                "tmp/release.js"
               ]
             },
             "development": {


### PR DESCRIPTION
Moved the `tmp/release.js` script to the `production` configuration section in `angular.json`. Development-like commands such as `ng serve` or `ng test` don't fail anymore. 

Running `ng build` will still fail if the `release.js` file is not present. This is because `ng build` runs in `prod` mode by default. I investigated if it was possible to add a prehook command to `ng build` but, it seems it's not: https://github.com/angular/angular-cli/issues/11787. So we'll have to stick with using the commands inside `package.json`. (`npm run build`) when deploying the site. (which was the status quo anyway).

Of course, running `ng build --configuration development` works and doesn't require the release file.

Fixes #177