### PR TITLE
package update and central management

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,7 +15,7 @@
     <PackageVersion Include="NuGet.Client" Version="4.3.0-beta1-2418" />
     <PackageVersion Include="NuGet.Protocol" Version="6.8.0" />
     <PackageVersion Include="RabbitMQ.Client" Version="6.8.1" />
-    <PackageVersion Include="Sentry" Version="4.0.0-beta.4" />
+    <PackageVersion Include="Sentry" Version="$(SentryVersion)" />
     <PackageVersion Include="Sentry.AspNetCore" Version="$(SentryVersion)" />
     <PackageVersion Include="Sentry.Serilog" Version="$(SentryVersion)" />
     <PackageVersion Include="Serilog.AspNetCore" Version="8.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,25 +3,25 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Hangfire.AspNetCore" Version="1.8.2" />
-    <PackageVersion Include="Hangfire.MemoryStorage" Version="1.7.0" />
-    <PackageVersion Include="MessagePack" Version="2.5.108" />
-    <PackageVersion Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0" />
+    <PackageVersion Include="Hangfire.AspNetCore" Version="1.8.7" />
+    <PackageVersion Include="Hangfire.MemoryStorage" Version="1.8.0" />
+    <PackageVersion Include="MessagePack" Version="2.5.140" />
+    <PackageVersion Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0-rc.2" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
     <PackageVersion Include="NuGet.Client" Version="4.3.0-beta1-2418" />
-    <PackageVersion Include="NuGet.Protocol" Version="6.6.1" />
-    <PackageVersion Include="RabbitMQ.Client" Version="6.5.0" />
-    <PackageVersion Include="Sentry" Version="$(SentryVersion)" />
+    <PackageVersion Include="NuGet.Protocol" Version="6.8.0" />
+    <PackageVersion Include="RabbitMQ.Client" Version="6.8.1" />
+    <PackageVersion Include="Sentry" Version="4.0.0-beta.4" />
     <PackageVersion Include="Sentry.AspNetCore" Version="$(SentryVersion)" />
     <PackageVersion Include="Sentry.Serilog" Version="$(SentryVersion)" />
-    <PackageVersion Include="Serilog.AspNetCore" Version="7.0.0" />
-    <PackageVersion Include="Serilog.Enrichers.Environment" Version="2.2.1-dev-00787" />
-    <PackageVersion Include="Serilog.Settings.Configuration" Version="7.0.0" />
-    <PackageVersion Include="Serilog.Sinks.Console" Version="4.1.0" />
+    <PackageVersion Include="Serilog.AspNetCore" Version="8.0.0" />
+    <PackageVersion Include="Serilog.Enrichers.Environment" Version="3.0.0-dev-00806" />
+    <PackageVersion Include="Serilog.Settings.Configuration" Version="8.0.0" />
+    <PackageVersion Include="Serilog.Sinks.Console" Version="5.0.1" />
     <PackageVersion Include="Shortr.AspNetCore" Version="1.0.0-beta01" />
     <PackageVersion Include="Shortr.Npgsql" Version="1.0.0-beta01" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,30 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Hangfire.AspNetCore" Version="1.8.2" />
+    <PackageVersion Include="Hangfire.MemoryStorage" Version="1.7.0" />
+    <PackageVersion Include="MessagePack" Version="2.5.108" />
+    <PackageVersion Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0-rc.2" />
+    <PackageVersion Include="NuGet.Client" Version="4.3.0-beta1-2418" />
+    <PackageVersion Include="NuGet.Protocol" Version="6.6.1" />
+    <PackageVersion Include="RabbitMQ.Client" Version="6.5.0" />
+    <PackageVersion Include="Sentry" Version="$(SentryVersion)" />
+    <PackageVersion Include="Sentry.AspNetCore" Version="$(SentryVersion)" />
+    <PackageVersion Include="Sentry.Serilog" Version="$(SentryVersion)" />
+    <PackageVersion Include="Serilog.AspNetCore" Version="7.0.0" />
+    <PackageVersion Include="Serilog.Enrichers.Environment" Version="2.2.1-dev-00787" />
+    <PackageVersion Include="Serilog.Settings.Configuration" Version="7.0.0" />
+    <PackageVersion Include="Serilog.Sinks.Console" Version="4.1.0" />
+    <PackageVersion Include="Shortr.AspNetCore" Version="1.0.0-beta01" />
+    <PackageVersion Include="Shortr.Npgsql" Version="1.0.0-beta01" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageVersion Include="UnoptimizedAssemblyDetector" Version="0.1.1" />
+  </ItemGroup>
+</Project>

--- a/NuGetTrends.sln
+++ b/NuGetTrends.sln
@@ -1,15 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27906.1
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34316.72
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGetTrends.Web", "src\NuGetTrends.Web\NuGetTrends.Web.csproj", "{74F6B811-9533-4C03-868C-BC1DBD3C4D22}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.Protocol.Catalog", "src\NuGet.Protocol.Catalog\NuGet.Protocol.Catalog.csproj", "{9691BF79-1E62-476B-85BA-5F7A06939E47}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGetTrends.Data", "src\NuGetTrends.Data\NuGetTrends.Data.csproj", "{473984CE-0211-406E-B545-C417BB5B79EC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGetTrends.Data", "src\NuGetTrends.Data\NuGetTrends.Data.csproj", "{473984CE-0211-406E-B545-C417BB5B79EC}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGetTrends.Scheduler", "src\NuGetTrends.Scheduler\NuGetTrends.Scheduler.csproj", "{A6E228CA-5E81-4B3C-82E3-5CF18BB0784D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGetTrends.Scheduler", "src\NuGetTrends.Scheduler\NuGetTrends.Scheduler.csproj", "{A6E228CA-5E81-4B3C-82E3-5CF18BB0784D}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{AD05B453-E249-4C71-84C4-B30F527DF9DB}"
 	ProjectSection(SolutionItems) = preProject
@@ -17,6 +17,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
 		src\Directory.Build.props = src\Directory.Build.props
+		Directory.Packages.props = Directory.Packages.props
 		docker-compose.yml = docker-compose.yml
 		global.json = global.json
 	EndProjectSection

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -18,6 +18,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="UnoptimizedAssemblyDetector" Version="0.1.1" PrivateAssets="All" />
+    <PackageReference Include="UnoptimizedAssemblyDetector" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/src/NuGet.Protocol.Catalog/Models/ModelExtensions.cs
+++ b/src/NuGet.Protocol.Catalog/Models/ModelExtensions.cs
@@ -92,7 +92,7 @@ public static class ModelExtensions
     /// </summary>
     /// <param name="leaf">The catalog leaf.</param>
     /// <returns>The package version.</returns>
-    private static NuGetVersion ParsePackageVersion(this ICatalogLeafItem leaf) => NuGetVersion.Parse(leaf.PackageVersion);
+    private static NuGetVersion ParsePackageVersion(this ICatalogLeafItem leaf) => NuGetVersion.Parse(leaf.PackageVersion!);
 
     /// <summary>
     /// Parse the target framework as a <see cref="NuGetFramework" />.

--- a/src/NuGet.Protocol.Catalog/NuGet.Protocol.Catalog.csproj
+++ b/src/NuGet.Protocol.Catalog/NuGet.Protocol.Catalog.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -9,10 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
-    <PackageReference Include="NuGet.Protocol" Version="6.6.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Sentry" Version="$(SentryVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="NuGet.Protocol" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="Sentry" />
   </ItemGroup>
 
 </Project>

--- a/src/NuGetTrends.Data/NuGetTrends.Data.csproj
+++ b/src/NuGetTrends.Data/NuGetTrends.Data.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -9,8 +9,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0-rc.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/src/NuGetTrends.Scheduler/NuGetTrends.Scheduler.csproj
+++ b/src/NuGetTrends.Scheduler/NuGetTrends.Scheduler.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -16,18 +16,18 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MessagePack" Version="2.5.108" />
-    <PackageReference Include="NuGet.Client" Version="4.3.0-beta1-2418" />
-    <PackageReference Include="RabbitMQ.Client" Version="6.5.0" />
-    <PackageReference Include="Hangfire.AspNetCore" Version="1.8.2" />
-    <PackageReference Include="Hangfire.MemoryStorage" Version="1.7.0" />
-    <PackageReference Include="Sentry.AspNetCore" Version="$(SentryVersion)" />
-    <PackageReference Include="Sentry.Serilog" Version="$(SentryVersion)" />
-    <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="7.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
-    <PackageReference Include="Serilog.Enrichers.Environment" Version="2.2.1-dev-00787" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+    <PackageReference Include="MessagePack" />
+    <PackageReference Include="NuGet.Client" />
+    <PackageReference Include="RabbitMQ.Client" />
+    <PackageReference Include="Hangfire.AspNetCore" />
+    <PackageReference Include="Hangfire.MemoryStorage" />
+    <PackageReference Include="Sentry.AspNetCore" />
+    <PackageReference Include="Sentry.Serilog" />
+    <PackageReference Include="Serilog.AspNetCore" />
+    <PackageReference Include="Serilog.Settings.Configuration" />
+    <PackageReference Include="Serilog.Sinks.Console" />
+    <PackageReference Include="Serilog.Enrichers.Environment" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/NuGetTrends.Web/NuGetTrends.Web.csproj
+++ b/src/NuGetTrends.Web/NuGetTrends.Web.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -13,16 +13,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="8.0.0" />
-    <PackageReference Include="Shortr.AspNetCore" Version="1.0.0-beta01" />
-    <PackageReference Include="Shortr.Npgsql" Version="1.0.0-beta01" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-    <PackageReference Include="Sentry.AspNetCore" Version="$(SentryVersion)" />
-    <PackageReference Include="Sentry.Serilog" Version="$(SentryVersion)" />
-    <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="7.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
-    <PackageReference Include="Serilog.Enrichers.Environment" Version="2.2.1-dev-00787" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" />
+    <PackageReference Include="Shortr.AspNetCore" />
+    <PackageReference Include="Shortr.Npgsql" />
+    <PackageReference Include="Swashbuckle.AspNetCore" />
+    <PackageReference Include="Sentry.AspNetCore" />
+    <PackageReference Include="Sentry.Serilog" />
+    <PackageReference Include="Serilog.AspNetCore" />
+    <PackageReference Include="Serilog.Settings.Configuration" />
+    <PackageReference Include="Serilog.Sinks.Console" />
+    <PackageReference Include="Serilog.Enrichers.Environment" />
   </ItemGroup>
 
   <ItemGroup>
@@ -40,7 +40,7 @@
     <!-- Include the newly-built spa files in the publish output -->
     <ItemGroup>
       <DistFiles Include="$(SpaRoot)dist/**" />
-      <ResolvedFileToPublish Include="@(DistFiles->'%(FullPath)')" Exclude="@(ResolvedFileToPublish)">
+      <ResolvedFileToPublish Include="@(DistFiles-&gt;'%(FullPath)')" Exclude="@(ResolvedFileToPublish)">
         <RelativePath>%(DistFiles.Identity)</RelativePath>
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
         <ExcludeFromSingleFile>true</ExcludeFromSingleFile>


### PR DESCRIPTION
This pull request includes:

- Moving nuget package version to a centralized place -> Directory.Packages.props
- Updating nuget package to their latest version
  - Includes fix for https://github.com/npgsql/npgsql/pull/5327 which is causing the DownloadCountImporter to fail as long as the Cursor value is DateTimeOffset.Minvalue, I encountered this when starting up the project without a database dump