### PR TITLE
Add BuiltWithDot.Net badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![Nuget Trends Web](https://github.com/dotnet/nuget-trends/workflows/Web/badge.svg)](https://github.com/dotnet/nuget-trends/actions?query=workflow%3AWeb)
 [![Codecov](https://img.shields.io/codecov/c/github/dotnet/nuget-trends?label=SPA%20-%20Coverage)](https://codecov.io/gh/dotnet/nuget-trends)
 [![Scheduler](https://github.com/dotnet/nuget-trends/workflows/Scheduler/badge.svg)](https://github.com/dotnet/nuget-trends/actions?query=workflow%3AScheduler)
+[![BuiltWithDot.Net shield](https://builtwithdot.net/project/414/nuget-trends/badge)](https://builtwithdot.net/project/414/nuget-trends)
 
 ## Summary
 


### PR DESCRIPTION
Since NuGet Trends is listed on BuiltWithDot.Net I've taken the liberty to raise a PR that adds the BuiltWithDot.Net badge for NuGet Trends to the README.md file. This will help promote your project, BuiltWithDot.Net, all other .NET developers that have projects listed on the site, and the open-source .NET ecosystem in general. If you have any questions or concerns, please let me know. Your help is much appreciated!

Thanks, Corstiaan (creator of BuiltWithDot.Net)

PS If you don't want to add the badge, that's totally fine. Just close this PR. No hard feelings :-)