### PR TITLE
bump MessagePack to version 2.5.187

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageVersion Include="Hangfire.AspNetCore" Version="1.8.7" />
     <PackageVersion Include="Hangfire.MemoryStorage" Version="1.8.0" />
-    <PackageVersion Include="MessagePack" Version="2.5.140" />
+    <PackageVersion Include="MessagePack" Version="2.5.187" />
     <PackageVersion Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="8.0.1" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />


### PR DESCRIPTION
### Fix for Build Error NU1902 - MessagePack Package Vulnerability

**Issue:** #271

**Description:** This PR addresses a build error due to NU1902, where a vulnerability warning in MessagePack (v2.5.140) is treated as an error, stopping the build.

**Solution:** Updated MessagePack to v2.5.187 to resolve the vulnerability (GitHub Advisory GHSA-4qm4-8hg2-g2xm), allowing the build to complete successfully.

**Test:** The repository was cloned and built successfully with the update, confirming the issue is resolved.