### PR TITLE
fix(spa): filter Angular animation timing errors from Sentry

### DIFF
--- a/src/NuGetTrends.Web/Portal/src/app/app.module.ts
+++ b/src/NuGetTrends.Web/Portal/src/app/app.module.ts
@@ -13,6 +13,7 @@ import { PackagesModule } from "./packages/packages.module";
 import { SharedModule } from "./shared/shared.module";
 import { HomeModule } from "./home/home.module";
 import { CoreModule } from "./core/core.module";
+import { filterNoisyErrors } from "./core/sentry-error-filter";
 
 Sentry.init({
   dsn: environment.SENTRY_DSN,
@@ -23,6 +24,7 @@ Sentry.init({
   replaysSessionSampleRate: 1.0,
   replaysOnErrorSampleRate: 1.0,
   profileSessionSampleRate: 1.0,
+  beforeSend: filterNoisyErrors,
   integrations: [
     Sentry.replayIntegration({
       // No PII here so lets get the texts

--- a/src/NuGetTrends.Web/Portal/src/app/core/sentry-error-filter.spec.ts
+++ b/src/NuGetTrends.Web/Portal/src/app/core/sentry-error-filter.spec.ts
@@ -1,0 +1,61 @@
+import { ErrorEvent, EventHint } from '@sentry/angular';
+import { filterNoisyErrors } from './sentry-error-filter';
+
+describe('Sentry Error Filter', () => {
+
+  describe('filterNoisyErrors', () => {
+
+    it('should filter out Angular animation addEventListener errors', () => {
+      const mockEvent = { event_id: 'test-123' } as ErrorEvent;
+      const mockHint = {
+        originalException: new TypeError("Cannot read properties of null (reading 'addEventListener')")
+      } as EventHint;
+
+      const result = filterNoisyErrors(mockEvent, mockHint);
+
+      expect(result).toBeNull();
+    });
+
+    it('should not filter out other TypeError errors', () => {
+      const mockEvent = { event_id: 'test-456' } as ErrorEvent;
+      const mockHint = {
+        originalException: new TypeError('Some other error')
+      } as EventHint;
+
+      const result = filterNoisyErrors(mockEvent, mockHint);
+
+      expect(result).toEqual(mockEvent);
+    });
+
+    it('should not filter out non-TypeError errors', () => {
+      const mockEvent = { event_id: 'test-789' } as ErrorEvent;
+      const mockHint = {
+        originalException: new Error('Some error')
+      } as EventHint;
+
+      const result = filterNoisyErrors(mockEvent, mockHint);
+
+      expect(result).toEqual(mockEvent);
+    });
+
+    it('should not filter out errors without originalException', () => {
+      const mockEvent = { event_id: 'test-abc' } as ErrorEvent;
+      const mockHint = {} as EventHint;
+
+      const result = filterNoisyErrors(mockEvent, mockHint);
+
+      expect(result).toEqual(mockEvent);
+    });
+
+    it('should handle null/undefined originalException gracefully', () => {
+      const mockEvent = { event_id: 'test-def' } as ErrorEvent;
+      const mockHint = { originalException: null } as unknown as EventHint;
+
+      const result = filterNoisyErrors(mockEvent, mockHint);
+
+      expect(result).toEqual(mockEvent);
+    });
+
+  });
+
+});

--- a/src/NuGetTrends.Web/Portal/src/app/core/sentry-error-filter.ts
+++ b/src/NuGetTrends.Web/Portal/src/app/core/sentry-error-filter.ts
@@ -1,0 +1,28 @@
+import { ErrorEvent, EventHint } from '@sentry/angular';
+
+/**
+ * Filters out known noisy errors that don't affect user experience.
+ * Used as the beforeSend callback for Sentry.
+ *
+ * @param event The Sentry error event
+ * @param hint Additional information about the error
+ * @returns The event to send, or null to drop it
+ */
+export function filterNoisyErrors(
+  event: ErrorEvent,
+  hint: EventHint
+): ErrorEvent | null {
+  const error = hint.originalException;
+
+  // Filter out Angular animation timing errors that occur when navigating
+  // away from a page before animations complete. These don't affect UX.
+  // See: https://nugettrends.sentry.io/issues/SPA-ZT
+  if (
+    error instanceof TypeError &&
+    error.message?.includes("Cannot read properties of null (reading 'addEventListener')")
+  ) {
+    return null;
+  }
+
+  return event;
+}


### PR DESCRIPTION
Add beforeSend filter to ignore 'Cannot read properties of null (reading addEventListener)' errors that occur when navigating away from a page before Angular animations complete. These errors don't affect user experience and are noise in error monitoring.

- Add filterNoisyErrors function with comprehensive tests
- Integrate filter into Sentry.init() beforeSend callback
- Filter is extensible for future noisy error patterns

Fixes SPA-ZT