### PR TITLE
fix(sentry): suppress SPA middleware errors for POST requests

### DIFF
--- a/src/NuGetTrends.Web/Program.cs
+++ b/src/NuGetTrends.Web/Program.cs
@@ -47,6 +47,17 @@ try
         {
             o.SetBeforeSend(e =>
             {
+                // Ignore SPA default page middleware errors for POST requests
+                // The SPA middleware doesn't support POST requests to index.html and this is expected behavior
+                // See: https://nugettrends.sentry.io/issues/4968360400/
+                if (e.Exception is InvalidOperationException &&
+                    e.Message?.Formatted is { } message &&
+                    message.Contains("The SPA default page middleware could not return the default page") &&
+                    e.Request?.Method == "POST")
+                {
+                    return null;
+                }
+
                 if (e.Message?.Formatted is { } msg && msg.Contains(
                         "An error occurred using the connection to database '\"nugettrends\"' on server"))
                 {


### PR DESCRIPTION
## Summary

- Filter out `InvalidOperationException` errors from the SPA default page middleware when the HTTP method is POST
- The SPA middleware doesn't support POST requests to `index.html` and this is expected behavior (bots/scanners hitting the server directly)

## Sentry Issue

Fixes [API-3Z](https://nugettrends.sentry.io/issues/4968360400/) - 1,617 occurrences from bots making POST requests to the server IP.

## Changes

Added a filter in the `SetBeforeSend` callback to return `null` (suppress the event) when:
- Exception is `InvalidOperationException`
- Message contains "The SPA default page middleware could not return the default page"
- HTTP method is `POST`