### PR TITLE
perf: replace per-package SELECT+INSERT/UPDATE with batch upsert

### DIFF
--- a/src/NuGetTrends.Data.Tests/PackageDownloadUpsertTests.cs
+++ b/src/NuGetTrends.Data.Tests/PackageDownloadUpsertTests.cs
@@ -1,0 +1,300 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NuGetTrends.Data.Tests.Infrastructure;
+using Xunit;
+
+namespace NuGetTrends.Data.Tests;
+
+/// <summary>
+/// Tests for the PostgreSQL batch upsert functionality used by DailyDownloadWorker
+/// to efficiently update package download records.
+/// </summary>
+[Collection("PostgreSql")]
+public class PackageDownloadUpsertTests : IAsyncLifetime
+{
+    private readonly PostgreSqlFixture _fixture;
+
+    public PackageDownloadUpsertTests(PostgreSqlFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.ResetDatabaseAsync();
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task UpsertPackageDownloadsAsync_NewPackages_InsertsAll()
+    {
+        // Arrange
+        var now = DateTime.UtcNow;
+        var packages = new List<PackageDownloadUpsert>
+        {
+            new("Sentry", 1000, now, "https://example.com/sentry.png"),
+            new("Newtonsoft.Json", 2000, now, "https://example.com/newtonsoft.png"),
+            new("Moq", 3000, now, null)
+        };
+
+        await using var context = _fixture.CreateDbContext();
+
+        // Act
+        var rowsAffected = await context.UpsertPackageDownloadsAsync(packages);
+
+        // Assert
+        rowsAffected.Should().Be(3);
+
+        var allPackages = await context.PackageDownloads.ToListAsync();
+        allPackages.Should().HaveCount(3);
+
+        var sentry = allPackages.Single(p => p.PackageId == "Sentry");
+        sentry.PackageIdLowered.Should().Be("sentry");
+        sentry.LatestDownloadCount.Should().Be(1000);
+        sentry.IconUrl.Should().Be("https://example.com/sentry.png");
+
+        var moq = allPackages.Single(p => p.PackageId == "Moq");
+        moq.IconUrl.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task UpsertPackageDownloadsAsync_ExistingPackages_UpdatesAll()
+    {
+        // Arrange - Seed existing data
+        var yesterday = DateTime.UtcNow.AddDays(-1);
+        await _fixture.SeedPackageDownloadsAsync(
+            ("Sentry", yesterday),
+            ("Newtonsoft.Json", yesterday)
+        );
+
+        var now = DateTime.UtcNow;
+        var packages = new List<PackageDownloadUpsert>
+        {
+            new("Sentry", 5000, now, "https://new-icon.com/sentry.png"),
+            new("Newtonsoft.Json", 6000, now, "https://new-icon.com/newtonsoft.png")
+        };
+
+        await using var context = _fixture.CreateDbContext();
+
+        // Act
+        var rowsAffected = await context.UpsertPackageDownloadsAsync(packages);
+
+        // Assert
+        rowsAffected.Should().Be(2);
+
+        var allPackages = await context.PackageDownloads.ToListAsync();
+        allPackages.Should().HaveCount(2);
+
+        var sentry = allPackages.Single(p => p.PackageIdLowered == "sentry");
+        sentry.LatestDownloadCount.Should().Be(5000);
+        sentry.IconUrl.Should().Be("https://new-icon.com/sentry.png");
+        sentry.LatestDownloadCountCheckedUtc.Should().BeCloseTo(now, TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public async Task UpsertPackageDownloadsAsync_MixedNewAndExisting_HandlesCorrectly()
+    {
+        // Arrange - Seed some existing data
+        var yesterday = DateTime.UtcNow.AddDays(-1);
+        await _fixture.SeedPackageDownloadsAsync(("Sentry", yesterday));
+
+        var now = DateTime.UtcNow;
+        var packages = new List<PackageDownloadUpsert>
+        {
+            new("Sentry", 5000, now, "https://updated.com/sentry.png"),      // Existing - update
+            new("Newtonsoft.Json", 6000, now, "https://new.com/newtonsoft.png") // New - insert
+        };
+
+        await using var context = _fixture.CreateDbContext();
+
+        // Act
+        var rowsAffected = await context.UpsertPackageDownloadsAsync(packages);
+
+        // Assert
+        rowsAffected.Should().Be(2);
+
+        var allPackages = await context.PackageDownloads.ToListAsync();
+        allPackages.Should().HaveCount(2);
+
+        allPackages.Should().Contain(p => p.PackageIdLowered == "sentry" && p.LatestDownloadCount == 5000);
+        allPackages.Should().Contain(p => p.PackageIdLowered == "newtonsoft.json" && p.LatestDownloadCount == 6000);
+    }
+
+    [Fact]
+    public async Task UpsertPackageDownloadsAsync_EmptyList_ReturnsZero()
+    {
+        // Arrange
+        var packages = new List<PackageDownloadUpsert>();
+
+        await using var context = _fixture.CreateDbContext();
+
+        // Act
+        var rowsAffected = await context.UpsertPackageDownloadsAsync(packages);
+
+        // Assert
+        rowsAffected.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task UpsertPackageDownloadsAsync_CaseInsensitiveConflict_UpdatesCorrectly()
+    {
+        // Arrange - Seed with lowercase
+        await _fixture.SeedPackageDownloadsAsync(("sentry", DateTime.UtcNow.AddDays(-1)));
+
+        var now = DateTime.UtcNow;
+        var packages = new List<PackageDownloadUpsert>
+        {
+            new("SENTRY", 9999, now, "https://updated.com/icon.png") // Different case
+        };
+
+        await using var context = _fixture.CreateDbContext();
+
+        // Act
+        var rowsAffected = await context.UpsertPackageDownloadsAsync(packages);
+
+        // Assert
+        rowsAffected.Should().Be(1);
+
+        var allPackages = await context.PackageDownloads.ToListAsync();
+        allPackages.Should().HaveCount(1);
+
+        var pkg = allPackages.Single();
+        pkg.PackageId.Should().Be("SENTRY"); // Updated to new casing
+        pkg.PackageIdLowered.Should().Be("sentry");
+        pkg.LatestDownloadCount.Should().Be(9999);
+    }
+
+    [Fact]
+    public async Task UpsertPackageDownloadsAsync_NullIconUrl_OverwritesExisting()
+    {
+        // Arrange - Seed with an icon URL
+        await using var seedContext = _fixture.CreateDbContext();
+        seedContext.PackageDownloads.Add(new PackageDownload
+        {
+            PackageId = "Sentry",
+            PackageIdLowered = "sentry",
+            LatestDownloadCount = 1000,
+            LatestDownloadCountCheckedUtc = DateTime.UtcNow.AddDays(-1),
+            IconUrl = "https://old-icon.com/sentry.png"
+        });
+        await seedContext.SaveChangesAsync();
+
+        var now = DateTime.UtcNow;
+        var packages = new List<PackageDownloadUpsert>
+        {
+            new("Sentry", 2000, now, null) // Null icon URL
+        };
+
+        await using var context = _fixture.CreateDbContext();
+
+        // Act
+        await context.UpsertPackageDownloadsAsync(packages);
+
+        // Assert - Icon URL should be overwritten with null
+        var pkg = await context.PackageDownloads.SingleAsync(p => p.PackageIdLowered == "sentry");
+        pkg.IconUrl.Should().BeNull();
+        pkg.LatestDownloadCount.Should().Be(2000);
+    }
+
+    [Fact]
+    public async Task UpsertPackageDownloadsAsync_LargeBatch_HandlesEfficiently()
+    {
+        // Arrange - Large batch of 500 packages
+        var now = DateTime.UtcNow;
+        var packages = Enumerable.Range(1, 500)
+            .Select(i => new PackageDownloadUpsert(
+                $"Package.{i}",
+                i * 100,
+                now,
+                $"https://example.com/package{i}.png"))
+            .ToList();
+
+        await using var context = _fixture.CreateDbContext();
+
+        // Act
+        var rowsAffected = await context.UpsertPackageDownloadsAsync(packages);
+
+        // Assert
+        rowsAffected.Should().Be(500);
+
+        var count = await context.PackageDownloads.CountAsync();
+        count.Should().Be(500);
+    }
+
+    [Fact]
+    public async Task UpsertPackageDownloadsAsync_SpecialCharactersInPackageId_HandlesCorrectly()
+    {
+        // Arrange
+        var now = DateTime.UtcNow;
+        var packages = new List<PackageDownloadUpsert>
+        {
+            new("My.Package.With.Dots", 1000, now, null),
+            new("Package-With-Dashes", 2000, now, null),
+            new("Package_With_Underscores", 3000, now, null)
+        };
+
+        await using var context = _fixture.CreateDbContext();
+
+        // Act
+        var rowsAffected = await context.UpsertPackageDownloadsAsync(packages);
+
+        // Assert
+        rowsAffected.Should().Be(3);
+
+        var allPackages = await context.PackageDownloads.ToListAsync();
+        allPackages.Should().HaveCount(3);
+        allPackages.Select(p => p.PackageId).Should().BeEquivalentTo(
+            "My.Package.With.Dots",
+            "Package-With-Dashes",
+            "Package_With_Underscores");
+    }
+
+    [Fact]
+    public async Task UpsertPackageDownloadsAsync_SqlInjectionAttempt_HandlesSafely()
+    {
+        // Arrange - Attempt SQL injection via package ID
+        var now = DateTime.UtcNow;
+        var packages = new List<PackageDownloadUpsert>
+        {
+            new("'; DROP TABLE package_downloads; --", 1000, now, null)
+        };
+
+        await using var context = _fixture.CreateDbContext();
+
+        // Act - Should not throw and should safely insert the malicious string
+        var rowsAffected = await context.UpsertPackageDownloadsAsync(packages);
+
+        // Assert
+        rowsAffected.Should().Be(1);
+
+        var pkg = await context.PackageDownloads.SingleAsync();
+        pkg.PackageId.Should().Be("'; DROP TABLE package_downloads; --");
+
+        // Table should still exist and be queryable
+        var count = await context.PackageDownloads.CountAsync();
+        count.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task UpsertPackageDownloadsAsync_VeryLargeDownloadCount_HandlesCorrectly()
+    {
+        // Arrange
+        var now = DateTime.UtcNow;
+        var packages = new List<PackageDownloadUpsert>
+        {
+            new("PopularPackage", long.MaxValue, now, null)
+        };
+
+        await using var context = _fixture.CreateDbContext();
+
+        // Act
+        var rowsAffected = await context.UpsertPackageDownloadsAsync(packages);
+
+        // Assert
+        rowsAffected.Should().Be(1);
+
+        var pkg = await context.PackageDownloads.SingleAsync();
+        pkg.LatestDownloadCount.Should().Be(long.MaxValue);
+    }
+}

--- a/src/NuGetTrends.Data/NuGetTrendsContextExtensions.cs
+++ b/src/NuGetTrends.Data/NuGetTrendsContextExtensions.cs
@@ -1,7 +1,17 @@
+using System.Text;
 using Microsoft.EntityFrameworkCore;
 using Npgsql;
 
 namespace NuGetTrends.Data;
+
+/// <summary>
+/// Data for upserting a package download record.
+/// </summary>
+public record PackageDownloadUpsert(
+    string PackageId,
+    long DownloadCount,
+    DateTime CheckedUtc,
+    string? IconUrl);
 
 public static class NuGetTrendsContextExtensions
 {
@@ -59,5 +69,69 @@ SELECT AVG(COALESCE(d.download_count, NULL)) AS download_count,
             .FromSqlRaw(sql, packageIdParam, monthsParam)
             // ReSharper restore FormatStringProblem
             .ToListAsync();
+    }
+
+    /// <summary>
+    /// Performs a batch upsert of package download records using PostgreSQL's
+    /// INSERT ... ON CONFLICT DO UPDATE (UPSERT) for optimal performance.
+    /// </summary>
+    /// <param name="context">DbContext to execute the upsert.</param>
+    /// <param name="packages">Collection of package download data to upsert.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Number of rows affected.</returns>
+    /// <remarks>
+    /// This replaces the previous pattern of SELECT + INSERT/UPDATE per package,
+    /// reducing database round-trips from N+1 to 1 for a batch of N packages.
+    /// </remarks>
+    public static async Task<int> UpsertPackageDownloadsAsync(
+        this NuGetTrendsContext context,
+        IReadOnlyList<PackageDownloadUpsert> packages,
+        CancellationToken ct = default)
+    {
+        if (packages.Count == 0)
+        {
+            return 0;
+        }
+
+        // Build parameterized query for batch upsert
+        // Using numbered parameters ($1, $2, etc.) for Npgsql
+        var sql = new StringBuilder();
+        sql.AppendLine("""
+            INSERT INTO package_downloads (package_id, package_id_lowered, latest_download_count, latest_download_count_checked_utc, icon_url)
+            VALUES
+            """);
+
+        var parameters = new List<object>();
+        var paramIndex = 1;
+
+        for (var i = 0; i < packages.Count; i++)
+        {
+            if (i > 0)
+            {
+                sql.AppendLine(",");
+            }
+
+            sql.Append($"(@p{paramIndex}, @p{paramIndex + 1}, @p{paramIndex + 2}, @p{paramIndex + 3}, @p{paramIndex + 4})");
+
+            var pkg = packages[i];
+            parameters.Add(new NpgsqlParameter($"p{paramIndex}", pkg.PackageId));
+            parameters.Add(new NpgsqlParameter($"p{paramIndex + 1}", pkg.PackageId.ToLowerInvariant()));
+            parameters.Add(new NpgsqlParameter($"p{paramIndex + 2}", pkg.DownloadCount));
+            parameters.Add(new NpgsqlParameter($"p{paramIndex + 3}", pkg.CheckedUtc));
+            parameters.Add(new NpgsqlParameter($"p{paramIndex + 4}", (object?)pkg.IconUrl ?? DBNull.Value));
+
+            paramIndex += 5;
+        }
+
+        sql.AppendLine();
+        sql.AppendLine("""
+            ON CONFLICT (package_id_lowered) DO UPDATE SET
+                package_id = EXCLUDED.package_id,
+                latest_download_count = EXCLUDED.latest_download_count,
+                latest_download_count_checked_utc = EXCLUDED.latest_download_count_checked_utc,
+                icon_url = EXCLUDED.icon_url
+            """);
+
+        return await context.Database.ExecuteSqlRawAsync(sql.ToString(), parameters, ct);
     }
 }


### PR DESCRIPTION
## Summary

Optimizes PostgreSQL writes in `DailyDownloadWorker` by using a single `INSERT ... ON CONFLICT DO UPDATE` query instead of N SELECT + N INSERT/UPDATE operations per batch.

## Performance Improvement

| Metric | Before | After |
|--------|--------|-------|
| DB round-trips per batch (100 packages) | ~101 (100 SELECTs + batched writes) | 1 |
| Query pattern | SELECT to check existence, then INSERT or UPDATE | Single UPSERT |

## Changes

### New: `UpsertPackageDownloadsAsync` Extension Method
- Uses PostgreSQL's `INSERT ... ON CONFLICT DO UPDATE` for atomic upsert
- Parameterized query prevents SQL injection
- Handles case changes in package IDs (updates `package_id` on conflict)
- Returns rows affected count

### Updated: `DailyDownloadWorker.UpdateDownloadCount`
- Collects package data into `PackageDownloadUpsert` records
- Executes single batch upsert instead of per-package operations
- Adds Sentry span with `db.system: postgresql` and `db.operation: UPSERT` attributes
- Deleted packages still processed individually (rare case, fine to keep separate)

### Tests
- 10 new tests covering:
  - New package inserts
  - Existing package updates
  - Mixed new/existing batches
  - Empty list handling
  - Case-insensitive conflict resolution
  - Null icon URL handling
  - Large batch (500 packages)
  - Special characters in package IDs
  - SQL injection prevention
  - Very large download counts

## Testing

All 88 tests pass including the 10 new upsert tests.