### PR TITLE
chore: migrate from ClickHouse.Client to official ClickHouse.Driver

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,7 +15,7 @@
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
     <PackageVersion Include="NuGet.Client" Version="4.3.0-beta1-2418" />
     <PackageVersion Include="NuGet.Protocol" Version="7.0.1" />
-    <PackageVersion Include="ClickHouse.Client" Version="7.14.0" />
+    <PackageVersion Include="ClickHouse.Driver" Version="0.9.0" />
     <PackageVersion Include="RabbitMQ.Client" Version="6.8.1" />
     <PackageVersion Include="Sentry" Version="$(SentryVersion)" />
     <PackageVersion Include="Sentry.AspNetCore" Version="$(SentryVersion)" />

--- a/scripts/seed-clickhouse-test-data.cs
+++ b/scripts/seed-clickhouse-test-data.cs
@@ -1,14 +1,14 @@
 #!/usr/bin/env dotnet
 
-#:package ClickHouse.Client@7.14.0
+#:package ClickHouse.Driver@0.9.0
 #:property ManagePackageVersionsCentrally=false
 #:property PublishAot=false
 
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using ClickHouse.Client.ADO;
-using ClickHouse.Client.Copy;
+using ClickHouse.Driver.ADO;
+using ClickHouse.Driver.Copy;
 
 // ============================================================================
 // Seed ClickHouse with test data for the 'sentry' package

--- a/src/NuGetTrends.Data.Tests/Infrastructure/ClickHouseFixture.cs
+++ b/src/NuGetTrends.Data.Tests/Infrastructure/ClickHouseFixture.cs
@@ -1,5 +1,5 @@
 using System.Runtime.CompilerServices;
-using ClickHouse.Client.ADO;
+using ClickHouse.Driver.ADO;
 using Testcontainers.ClickHouse;
 using Xunit;
 

--- a/src/NuGetTrends.Data/ClickHouse/ClickHouseService.cs
+++ b/src/NuGetTrends.Data/ClickHouse/ClickHouseService.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using System.Runtime.CompilerServices;
-using ClickHouse.Client.ADO;
-using ClickHouse.Client.Copy;
+using ClickHouse.Driver.ADO;
+using ClickHouse.Driver.Copy;
 using Microsoft.Extensions.Logging;
 
 namespace NuGetTrends.Data.ClickHouse;

--- a/src/NuGetTrends.Data/NuGetTrends.Data.csproj
+++ b/src/NuGetTrends.Data/NuGetTrends.Data.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" />
-    <PackageReference Include="ClickHouse.Client" />
+    <PackageReference Include="ClickHouse.Driver" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />

--- a/src/NuGetTrends.IntegrationTests/Infrastructure/IntegrationTestFixture.cs
+++ b/src/NuGetTrends.IntegrationTests/Infrastructure/IntegrationTestFixture.cs
@@ -1,5 +1,5 @@
 using System.Runtime.CompilerServices;
-using ClickHouse.Client.ADO;
+using ClickHouse.Driver.ADO;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using NuGet.Protocol.Catalog;

--- a/src/NuGetTrends.IntegrationTests/NuGetTrends.IntegrationTests.csproj
+++ b/src/NuGetTrends.IntegrationTests/NuGetTrends.IntegrationTests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClickHouse.Client" />
+    <PackageReference Include="ClickHouse.Driver" />
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />


### PR DESCRIPTION
## Summary

Migrate from the community `ClickHouse.Client` package (by DarkWanderer) to the official `ClickHouse.Driver` package (v0.9.0) published by ClickHouse Inc.

- Update package reference: `ClickHouse.Client` 7.14.0 → `ClickHouse.Driver` 0.9.0
- Update namespaces: `ClickHouse.Client.*` → `ClickHouse.Driver.*`

## Details

The `ClickHouse.Client` library by DarkWanderer was [adopted as the official ClickHouse .NET client](https://clickhouse.com/docs/integrations/csharp) and is now published under the `ClickHouse.Driver` package name by ClickHouse Inc.

This is essentially a namespace-only change as the API is identical - the same codebase is now maintained officially.

## Files Changed

| File | Change |
|------|--------|
| `Directory.Packages.props` | Package version update |
| `src/NuGetTrends.Data/NuGetTrends.Data.csproj` | Package reference |
| `src/NuGetTrends.Data/ClickHouse/ClickHouseService.cs` | Namespace update |
| `src/NuGetTrends.Data.Tests/Infrastructure/ClickHouseFixture.cs` | Namespace update |
| `src/NuGetTrends.IntegrationTests/NuGetTrends.IntegrationTests.csproj` | Package reference |
| `src/NuGetTrends.IntegrationTests/Infrastructure/IntegrationTestFixture.cs` | Namespace update |
| `scripts/seed-clickhouse-test-data.cs` | Package + namespace update |

## Testing

All 141 tests pass locally.

Closes #306