### PR TITLE
feat: support NuGet-style URLs for package pages

### DIFF
--- a/src/NuGetTrends.Web/Portal/src/app/app-routes.module.ts
+++ b/src/NuGetTrends.Web/Portal/src/app/app-routes.module.ts
@@ -5,6 +5,7 @@ import { HomeComponent } from './home/home.component';
 
 const routes: Routes = [
   {path: '', component: HomeComponent, pathMatch: 'full'},
+  {path: 'packages/:packageId', component: PackagesComponent},
   {path: 'packages', component: PackagesComponent}
 ];
 

--- a/src/NuGetTrends.Web/Portal/src/app/mocks/router-mock.ts
+++ b/src/NuGetTrends.Web/Portal/src/app/mocks/router-mock.ts
@@ -19,11 +19,13 @@ export class MockedActivatedRoute  {
 
   constructor() {
     this.testParamMap = {};
+    this.testPathParamMap = {};
   }
 
   private subject = new BehaviorSubject(convertToParamMap(this.testParamMap));
   paramMap = this.subject.asObservable();
   private _testParamMap!: ParamMap;
+  private _testPathParamMap!: ParamMap;
 
   get testParamMap() {
     return this._testParamMap;
@@ -34,8 +36,20 @@ export class MockedActivatedRoute  {
     this.subject.next(this._testParamMap);
   }
 
+  get testPathParamMap() {
+    return this._testPathParamMap;
+  }
+
+  set testPathParamMap(params: {}) {
+    this._testPathParamMap = convertToParamMap(params);
+  }
+
   get snapshot() {
-    return { queryParamMap: this.testParamMap };
+    return {
+      queryParamMap: this.testParamMap,
+      queryParams: {},
+      paramMap: this.testPathParamMap
+    };
   }
 
   static injectMockActivatedRoute() {

--- a/src/NuGetTrends.Web/Portal/src/app/packages/packages.component.spec.ts
+++ b/src/NuGetTrends.Web/Portal/src/app/packages/packages.component.spec.ts
@@ -141,6 +141,25 @@ describe('PackagesComponent', () => {
 
       expect(mockedToastr.error).toHaveBeenCalled();
     }));
+
+    it('should load package from NuGet-style URL path parameter (/packages/:packageId)', fakeAsync(() => {
+      spyOn(mockedPackageService, 'getPackageDownloadHistory').and.callThrough();
+      spyOn(packageInteractionService, 'addPackage').and.callThrough();
+      spyOn(packageInteractionService, 'plotPackage').and.callThrough();
+
+      // Set path parameter (NuGet-style URL: /packages/EntityFramework)
+      activatedRoute.testPathParamMap = { packageId: 'EntityFramework' };
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      const actualPackageElements: HTMLElement[] = fixture.nativeElement.querySelectorAll('.tags span');
+
+      expect(actualPackageElements.length).toBe(1);
+      expect(mockedPackageService.getPackageDownloadHistory).toHaveBeenCalledTimes(1);
+      expect(packageInteractionService.addPackage).toHaveBeenCalledTimes(1);
+      expect(packageInteractionService.plotPackage).toHaveBeenCalledTimes(1);
+    }));
   });
 
   describe('Period Changed', () => {
@@ -380,6 +399,28 @@ describe('PackagesComponent', () => {
       expect(navigateActualParams[1].queryParams[queryParamName]).toEqual(['EntityFramework', 'Dapper']);
       expect(navigateActualParams[1].replaceUrl).toBeTruthy();
       expect(navigateActualParams[1].queryParamsHandling).toBe('merge');
+    }));
+
+    it('should transition from NuGet-style URL to query params when adding second package', fakeAsync(() => {
+      const spy = spyOn(router, 'navigate').and.callThrough();
+
+      // Start with NuGet-style URL (/packages/EntityFramework)
+      activatedRoute.testPathParamMap = { packageId: 'EntityFramework' };
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      // Act - Add a second package via plotPackage
+      packageInteractionService.plotPackage(PackagesServiceMock.mockedDownloadHistory[1]);
+      fixture.detectChanges();
+      tick();
+
+      const navigateActualParams: any[] = spy.calls.mostRecent().args;
+
+      // Should navigate to /packages with both packages as query params
+      expect(navigateActualParams[0]).toEqual(['/packages']);
+      expect(navigateActualParams[1].queryParams[queryParamName]).toEqual(['EntityFramework', 'Dapper']);
+      expect(navigateActualParams[1].replaceUrl).toBeTruthy();
     }));
   });
 });


### PR DESCRIPTION
## Summary

Adds support for NuGet-style URLs like `/packages/Newtonsoft.Json` that match NuGet's URL structure, allowing users to easily switch from nuget.org to nugettrends.com by simply changing the domain.

Closes #199

## Changes

- Add new route `packages/:packageId` in `app-routes.module.ts`
- Update `PackagesComponent` to load packages from path parameter
- Automatically transition to query param format (`/packages?ids=...`) when adding a second package
- Add tests for NuGet-style URL functionality

## URL Behavior

| URL | Behavior |
|-----|----------|
| `/packages/Newtonsoft.Json` | Loads the package chart directly (no redirect) |
| `/packages/Newtonsoft.Json?months=12` | Loads with custom period |
| `/packages/Foo` + add `Bar` | URL transitions to `/packages?ids=Foo&ids=Bar&months=24` |
| `/packages?ids=Foo` | Existing behavior preserved (backward compatible) |

## Testing

- All 59 Angular unit tests pass
- Build succeeds
- 2 new tests added specifically for NuGet-style URL support