### PR TITLE
feat: update time range selector with more options

### DIFF
--- a/src/NuGetTrends.Web/Portal/src/app/packages/packages.component.ts
+++ b/src/NuGetTrends.Web/Portal/src/app/packages/packages.component.ts
@@ -383,17 +383,15 @@ export class PackagesComponent implements OnInit, OnDestroy {
   }
 
   /**
- * Gets correctly formated date depending on the period
- */
-  private getTimeUnit(period: number): any {
-    if (period >= 3 && period <= 6) {
+   * Gets correctly formatted date depending on the period
+   */
+  private getTimeUnit(period: number): 'day' | 'month' | 'year' {
+    if (period <= 6) {
       return 'day';
-    } else if (period >= 12 && period <= 24) {
+    } else if (period <= 24) {
       return 'month';
-    } else if (period >= 72 && period <= 120) {
-      return 'year';
     } else {
-      return 'month';
+      return 'year';
     }
   }
 }

--- a/src/NuGetTrends.Web/Portal/src/app/shared/models/package-models.ts
+++ b/src/NuGetTrends.Web/Portal/src/app/shared/models/package-models.ts
@@ -70,13 +70,24 @@ export class SearchPeriod {
   }
 }
 
+// NuGet Trends has data starting from January 2012
+const DATA_START_DATE = new Date(2012, 0, 1);
+
+function calculateAllTimeMonths(): number {
+  const now = new Date();
+  const months = (now.getFullYear() - DATA_START_DATE.getFullYear()) * 12
+    + (now.getMonth() - DATA_START_DATE.getMonth());
+  return months;
+}
+
 const DefaultSearchPeriods: Array<SearchPeriod> = [
   {value: 3, text: '3 months'},
   {value: 6, text: '6 months'},
   {value: 12, text: '1 year'},
   {value: 24, text: '2 years'},
-  {value: 72, text: '6 years'},
-  {value: 120, text: '10 years'}
+  {value: 60, text: '5 years'},
+  {value: 120, text: '10 years'},
+  {value: calculateAllTimeMonths(), text: 'All time'}
 ];
 
 const InitialSearchPeriod: SearchPeriod = DefaultSearchPeriods[3];


### PR DESCRIPTION
## Summary
- Add "All time" option (180 months) to view historical data back to 2012
- Replace "6 years" with "5 years" for better granularity
- Simplify `getTimeUnit()` logic to handle any period value

Closes #301