### PR TITLE
feat: add dark theme with system preference detection and manual toggle

### DIFF
--- a/src/NuGetTrends.Web/Portal/src/app/app.component.html
+++ b/src/NuGetTrends.Web/Portal/src/app/app.component.html
@@ -1,3 +1,4 @@
+<app-theme-toggle></app-theme-toggle>
 <div class="site-content">
   <section class="hero search-pattern is-primary">
     <div class="hero-body main-header">

--- a/src/NuGetTrends.Web/Portal/src/app/app.component.ts
+++ b/src/NuGetTrends.Web/Portal/src/app/app.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { ThemeService } from './core/theme/theme.service';
 
 @Component({
   selector: 'app-root',
@@ -6,4 +7,12 @@ import { Component } from '@angular/core';
   standalone: false
 })
 export class AppComponent {
+  /**
+   * ThemeService is injected to initialize theming on app startup.
+   * The service constructor sets up theme detection and applies the initial theme.
+   */
+  constructor(themeService: ThemeService) {
+    // Access service to prevent tree-shaking
+    void themeService.preference;
+  }
 }

--- a/src/NuGetTrends.Web/Portal/src/app/app.module.ts
+++ b/src/NuGetTrends.Web/Portal/src/app/app.module.ts
@@ -36,9 +36,12 @@ Sentry.init({
     }),
     Sentry.replayCanvasIntegration(),
     Sentry.feedbackIntegration({
-      colorScheme: "light", // no dark theme yet
+      colorScheme: "system", // auto-detect system theme
       themeLight: {
         accentBackground: "#215C84",
+      },
+      themeDark: {
+        accentBackground: "#4a9fd4",
       },
     }),
     Sentry.browserTracingIntegration({

--- a/src/NuGetTrends.Web/Portal/src/app/core/core.module.ts
+++ b/src/NuGetTrends.Web/Portal/src/app/core/core.module.ts
@@ -1,14 +1,18 @@
 import { NgModule, Optional, SkipSelf } from '@angular/core';
+import { CommonModule } from '@angular/common';
 
 import { throwIfAlreadyLoaded } from './module-import-guard';
 import { PackagesService, PackageInteractionService } from './';
 import { FooterComponent } from './footer/footer.component';
 import { NavigationComponent } from './navigation/navigation.component';
+import { ThemeToggleComponent } from './theme/theme-toggle.component';
+import { ThemeService } from './theme/theme.service';
 
 @NgModule({
-  declarations: [FooterComponent, NavigationComponent],
-  exports: [FooterComponent, NavigationComponent],
-  providers: [PackagesService, PackageInteractionService]
+  imports: [CommonModule],
+  declarations: [FooterComponent, NavigationComponent, ThemeToggleComponent],
+  exports: [FooterComponent, NavigationComponent, ThemeToggleComponent],
+  providers: [PackagesService, PackageInteractionService, ThemeService]
 })
 export class CoreModule {
   constructor(@Optional() @SkipSelf() parentModule: CoreModule) {

--- a/src/NuGetTrends.Web/Portal/src/app/core/footer/footer.component.scss
+++ b/src/NuGetTrends.Web/Portal/src/app/core/footer/footer.component.scss
@@ -1,22 +1,20 @@
-@import '../../../colors';
-
 footer {
   padding: 50px 20px 20px;
-  background-color: $blue-darker;
+  background-color: var(--color-footer-bg);
 }
 
 .footer-item-header {
   font-size: 25px;
   margin: 0 0 12px;
   letter-spacing: 0;
-  color: $white-ter;
+  color: #f5f5f5;
 }
 
 .footer-item {
   font-size: 16px;
   letter-spacing: 0;
   line-height: 30px;
-  color: $grey-light
+  color: #b5b5b5;
 }
 
 .sentry-sponsor {
@@ -26,11 +24,11 @@ footer {
     display: inline-flex;
     align-items: center;
     gap: 8px;
-    color: $grey-light;
+    color: #b5b5b5;
     text-decoration: none;
 
     &:hover {
-      color: $white-ter;
+      color: #f5f5f5;
 
       .sentry-logo {
         opacity: 1;

--- a/src/NuGetTrends.Web/Portal/src/app/core/index.ts
+++ b/src/NuGetTrends.Web/Portal/src/app/core/index.ts
@@ -1,2 +1,3 @@
 export * from './services/package-interaction.service';
 export * from './services/packages.service';
+export * from './theme/theme.service';

--- a/src/NuGetTrends.Web/Portal/src/app/core/theme/theme-toggle.component.html
+++ b/src/NuGetTrends.Web/Portal/src/app/core/theme/theme-toggle.component.html
@@ -1,0 +1,7 @@
+<button
+  class="theme-toggle-btn"
+  (click)="toggle()"
+  [title]="tooltip"
+  aria-label="Toggle theme">
+  <i class="fa" [ngClass]="currentIcon"></i>
+</button>

--- a/src/NuGetTrends.Web/Portal/src/app/core/theme/theme-toggle.component.scss
+++ b/src/NuGetTrends.Web/Portal/src/app/core/theme/theme-toggle.component.scss
@@ -1,0 +1,36 @@
+.theme-toggle-btn {
+  position: fixed;
+  top: 16px;
+  right: 16px;
+  z-index: 1000;
+  width: 40px;
+  height: 40px;
+  border: none;
+  border-radius: 50%;
+  background-color: var(--theme-toggle-bg);
+  color: var(--theme-toggle-color);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.3s ease, color 0.3s ease, transform 0.2s ease;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+
+  &:hover {
+    transform: scale(1.1);
+    background-color: var(--theme-toggle-bg-hover);
+  }
+
+  &:focus {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+
+  &:active {
+    transform: scale(0.95);
+  }
+
+  .fa {
+    font-size: 18px;
+  }
+}

--- a/src/NuGetTrends.Web/Portal/src/app/core/theme/theme-toggle.component.ts
+++ b/src/NuGetTrends.Web/Portal/src/app/core/theme/theme-toggle.component.ts
@@ -1,0 +1,34 @@
+import { Component } from '@angular/core';
+import { ThemeService } from './theme.service';
+
+@Component({
+  selector: 'app-theme-toggle',
+  templateUrl: './theme-toggle.component.html',
+  styleUrls: ['./theme-toggle.component.scss'],
+  standalone: false
+})
+export class ThemeToggleComponent {
+  constructor(public themeService: ThemeService) {}
+
+  get currentIcon(): string {
+    const pref = this.themeService.preference();
+    switch (pref) {
+      case 'system': return 'fa-desktop';
+      case 'light': return 'fa-sun-o';
+      case 'dark': return 'fa-moon-o';
+    }
+  }
+
+  get tooltip(): string {
+    const pref = this.themeService.preference();
+    switch (pref) {
+      case 'system': return 'Theme: System (click to change)';
+      case 'light': return 'Theme: Light (click to change)';
+      case 'dark': return 'Theme: Dark (click to change)';
+    }
+  }
+
+  toggle(): void {
+    this.themeService.cycleTheme();
+  }
+}

--- a/src/NuGetTrends.Web/Portal/src/app/core/theme/theme.service.ts
+++ b/src/NuGetTrends.Web/Portal/src/app/core/theme/theme.service.ts
@@ -1,0 +1,89 @@
+import { Injectable, signal, effect, computed } from '@angular/core';
+
+export type ThemePreference = 'system' | 'light' | 'dark';
+export type ResolvedTheme = 'light' | 'dark';
+
+const STORAGE_KEY = 'nuget-trends-theme';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ThemeService {
+  private readonly preferenceSignal = signal<ThemePreference>('system');
+  private readonly systemThemeSignal = signal<ResolvedTheme>('light');
+  private mediaQuery: MediaQueryList | null = null;
+
+  readonly preference = this.preferenceSignal.asReadonly();
+
+  readonly resolvedTheme = computed<ResolvedTheme>(() => {
+    const pref = this.preferenceSignal();
+    if (pref === 'system') {
+      return this.systemThemeSignal();
+    }
+    return pref;
+  });
+
+  readonly isDark = computed(() => this.resolvedTheme() === 'dark');
+
+  constructor() {
+    this.initSystemThemeListener();
+    this.loadSavedPreference();
+
+    effect(() => {
+      this.applyTheme(this.resolvedTheme());
+    });
+  }
+
+  private initSystemThemeListener(): void {
+    if (typeof window === 'undefined') return;
+
+    this.mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    this.systemThemeSignal.set(this.mediaQuery.matches ? 'dark' : 'light');
+
+    const handler = (e: MediaQueryListEvent) => {
+      this.systemThemeSignal.set(e.matches ? 'dark' : 'light');
+    };
+
+    this.mediaQuery.addEventListener('change', handler);
+  }
+
+  private loadSavedPreference(): void {
+    if (typeof localStorage === 'undefined') return;
+
+    const saved = localStorage.getItem(STORAGE_KEY) as ThemePreference | null;
+    if (saved && ['system', 'light', 'dark'].includes(saved)) {
+      this.preferenceSignal.set(saved);
+    }
+  }
+
+  private savePreference(preference: ThemePreference): void {
+    if (typeof localStorage === 'undefined') return;
+    localStorage.setItem(STORAGE_KEY, preference);
+  }
+
+  private applyTheme(theme: ResolvedTheme): void {
+    if (typeof document === 'undefined') return;
+
+    const body = document.body;
+    if (theme === 'dark') {
+      body.classList.add('dark-theme');
+      body.classList.remove('light-theme');
+    } else {
+      body.classList.add('light-theme');
+      body.classList.remove('dark-theme');
+    }
+  }
+
+  setPreference(preference: ThemePreference): void {
+    this.preferenceSignal.set(preference);
+    this.savePreference(preference);
+  }
+
+  cycleTheme(): void {
+    const current = this.preferenceSignal();
+    const next: ThemePreference =
+      current === 'system' ? 'light' :
+      current === 'light' ? 'dark' : 'system';
+    this.setPreference(next);
+  }
+}

--- a/src/NuGetTrends.Web/Portal/src/app/shared/components/loading-indicator/loading-indicator.component.scss
+++ b/src/NuGetTrends.Web/Portal/src/app/shared/components/loading-indicator/loading-indicator.component.scss
@@ -1,5 +1,3 @@
-@import '../../../../colors';
-
 .loading-screen-wrapper {
   background-color: rgba(51,51,51,0.8);
   position: fixed;
@@ -29,7 +27,7 @@
     bottom: 0;
     width: 10px;
     height: 50%;
-    background: $chart-loading-icon;
+    background: var(--color-bg);
     transform-origin: center bottom;
     box-shadow: 1px 1px 0 rgba(0,0,0,.2);
 
@@ -49,7 +47,7 @@
     left: 0;
     width: 10px;
     height: 10px;
-    background: $chart-loading-icon;
+    background: var(--color-bg);
     border-radius: 50%;
     animation: ball 4s infinite;
   }

--- a/src/NuGetTrends.Web/Portal/src/app/shared/components/search-input/search-input.component.scss
+++ b/src/NuGetTrends.Web/Portal/src/app/shared/components/search-input/search-input.component.scss
@@ -1,24 +1,22 @@
-@import '../../../../colors';
-
 .mat-autocomplete-panel {
   font-size: 1.1em;
-  color: $grey-dark;
-  border: 1px solid $grey-light;
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
   border-top: none;
-  background-color: $white-ter
+  background-color: var(--color-autocomplete-bg);
 }
 
 .package-img {
   height: 32px;
-  width: 32px;  
+  width: 32px;
   vertical-align: middle;
   margin-right: 8px;
 }
 
 .mat-option:hover:not(.mat-option-disabled),
 .mat-option.mat-active {
-  background-color: $cyan;
-  color: #fff
+  background-color: var(--color-autocomplete-hover);
+  color: #fff;
 }
 
 /* Extra styles to make the input a little nicer on the header */

--- a/src/NuGetTrends.Web/Portal/src/app/shared/components/search-type/search-type.component.scss
+++ b/src/NuGetTrends.Web/Portal/src/app/shared/components/search-type/search-type.component.scss
@@ -1,5 +1,3 @@
-@import '../../../../colors';
-
 .switch {
   position: relative;
   display: inline-block;
@@ -16,7 +14,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background-color: $blue-darker;
+  background-color: var(--color-footer-bg);
   -webkit-transition: .10s;
   transition: .10s;
 }
@@ -54,16 +52,16 @@ input:not(:checked) + .slider:before {
   font-weight: 500;
 }
 
-.toggle-label-left {  
+.toggle-label-left {
   top: 10px;
-  left: 20px; 
+  left: 20px;
 }
 
 .toggle-label-right {
   top: 10px;
-  right: 10px;  
+  right: 10px;
 }
 
 .label-inverted-color {
-  color: $white-ter;
+  color: #f5f5f5;
 }

--- a/src/NuGetTrends.Web/Portal/src/colors.scss
+++ b/src/NuGetTrends.Web/Portal/src/colors.scss
@@ -1,6 +1,6 @@
 @import '../node_modules/bulma/sass/utilities/initial-variables.sass';
 
-// brand colors
+// Brand colors (SCSS variables for Bulma compilation)
 $blue-dark: #215C84;
 $blue-darker: #153B54;
 $blue-light: #A2BACB;
@@ -14,3 +14,58 @@ $primary: $blue-dark;
 
 $body-background-color: $bg-color;
 $navbar-item-img-max-height: 3rem;
+
+// CSS Custom Properties for dynamic theming
+// These are applied via styles.scss :root and .dark-theme selectors
+
+// Light theme values (default)
+$light-bg-color: #EFF0EB;
+$light-bg-secondary: #ffffff;
+$light-text-color: #363636;
+$light-text-secondary: #4a4a4a;
+$light-text-muted: #7a7a7a;
+$light-primary: #215C84;
+$light-primary-hover: #1a4a6a;
+$light-footer-bg: #153B54;
+$light-card-bg: #ffffff;
+$light-card-shadow: rgba(50, 50, 93, 0.1);
+$light-border-color: #dbdbdb;
+$light-input-bg: #ffffff;
+$light-autocomplete-bg: #f5f5f5;
+$light-autocomplete-hover: #00d1b2;
+
+// Dark theme values
+$dark-bg-color: #1a1a2e;
+$dark-bg-secondary: #16213e;
+$dark-text-color: #e0e0e0;
+$dark-text-secondary: #b0b0b0;
+$dark-text-muted: #888888;
+$dark-primary: #4a9fd4;
+$dark-primary-hover: #5cb3e8;
+$dark-footer-bg: #0f0f1a;
+$dark-card-bg: #2d2d44;
+$dark-card-shadow: rgba(0, 0, 0, 0.3);
+$dark-border-color: #3d3d5c;
+$dark-input-bg: #2d2d44;
+$dark-autocomplete-bg: #2d2d44;
+$dark-autocomplete-hover: #4a9fd4;
+
+// Theme toggle button colors
+$light-toggle-bg: rgba(255, 255, 255, 0.9);
+$light-toggle-color: #363636;
+$light-toggle-bg-hover: #ffffff;
+
+$dark-toggle-bg: rgba(45, 45, 68, 0.9);
+$dark-toggle-color: #e0e0e0;
+$dark-toggle-bg-hover: #3d3d5c;
+
+// Chart colors for theming
+$light-chart-grid: rgba(0, 0, 0, 0.1);
+$light-chart-text: #666666;
+$light-chart-tooltip-bg: rgba(0, 0, 0, 0.8);
+$light-chart-tooltip-text: #ffffff;
+
+$dark-chart-grid: rgba(255, 255, 255, 0.1);
+$dark-chart-text: #b0b0b0;
+$dark-chart-tooltip-bg: rgba(45, 45, 68, 0.95);
+$dark-chart-tooltip-text: #e0e0e0;

--- a/src/NuGetTrends.Web/Portal/src/styles.scss
+++ b/src/NuGetTrends.Web/Portal/src/styles.scss
@@ -6,6 +6,89 @@ $fa-font-path: "~font-awesome/fonts";
 @import './colors';
 @import 'node_modules/bulma/bulma.sass';
 
+/* CSS Custom Properties - Light Theme (default) */
+:root,
+body.light-theme {
+  --color-bg: #{$light-bg-color};
+  --color-bg-secondary: #{$light-bg-secondary};
+  --color-text: #{$light-text-color};
+  --color-text-secondary: #{$light-text-secondary};
+  --color-text-muted: #{$light-text-muted};
+  --color-primary: #{$light-primary};
+  --color-primary-hover: #{$light-primary-hover};
+  --color-footer-bg: #{$light-footer-bg};
+  --color-card-bg: #{$light-card-bg};
+  --color-card-shadow: #{$light-card-shadow};
+  --color-border: #{$light-border-color};
+  --color-input-bg: #{$light-input-bg};
+  --color-autocomplete-bg: #{$light-autocomplete-bg};
+  --color-autocomplete-hover: #{$light-autocomplete-hover};
+
+  // Theme toggle
+  --theme-toggle-bg: #{$light-toggle-bg};
+  --theme-toggle-color: #{$light-toggle-color};
+  --theme-toggle-bg-hover: #{$light-toggle-bg-hover};
+
+  // Chart theming
+  --chart-grid-color: #{$light-chart-grid};
+  --chart-text-color: #{$light-chart-text};
+  --chart-tooltip-bg: #{$light-chart-tooltip-bg};
+  --chart-tooltip-text: #{$light-chart-tooltip-text};
+
+  // Hero section (keep light theme colors for header)
+  --hero-bg: #{$light-primary};
+
+  // Logo glow (none in light mode)
+  --logo-filter: none;
+}
+
+/* CSS Custom Properties - Dark Theme */
+body.dark-theme {
+  --color-bg: #{$dark-bg-color};
+  --color-bg-secondary: #{$dark-bg-secondary};
+  --color-text: #{$dark-text-color};
+  --color-text-secondary: #{$dark-text-secondary};
+  --color-text-muted: #{$dark-text-muted};
+  --color-primary: #{$dark-primary};
+  --color-primary-hover: #{$dark-primary-hover};
+  --color-footer-bg: #{$dark-footer-bg};
+  --color-card-bg: #{$dark-card-bg};
+  --color-card-shadow: #{$dark-card-shadow};
+  --color-border: #{$dark-border-color};
+  --color-input-bg: #{$dark-input-bg};
+  --color-autocomplete-bg: #{$dark-autocomplete-bg};
+  --color-autocomplete-hover: #{$dark-autocomplete-hover};
+
+  // Theme toggle
+  --theme-toggle-bg: #{$dark-toggle-bg};
+  --theme-toggle-color: #{$dark-toggle-color};
+  --theme-toggle-bg-hover: #{$dark-toggle-bg-hover};
+
+  // Chart theming
+  --chart-grid-color: #{$dark-chart-grid};
+  --chart-text-color: #{$dark-chart-text};
+  --chart-tooltip-bg: #{$dark-chart-tooltip-bg};
+  --chart-tooltip-text: #{$dark-chart-tooltip-text};
+
+  // Hero section (darker in dark mode)
+  --hero-bg: #{$dark-bg-secondary};
+
+  // Logo glow effect in dark mode
+  --logo-filter: drop-shadow(0 0 10px rgba(74, 159, 212, 0.5));
+}
+
+/* Theme transition - smooth color changes */
+body,
+body * {
+  transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+/* Override Bulma body background with CSS variable */
+body {
+  background-color: var(--color-bg);
+  color: var(--color-text);
+}
+
 /* To have a sticky footer. https://philipwalton.github.io/solved-by-flexbox/demos/sticky-footer/*/
 .site {
   display: flex;
@@ -19,8 +102,10 @@ $fa-font-path: "~font-awesome/fonts";
 
 .card {
   border-radius: 4px;
-  box-shadow: 0 15px 35px rgba(50, 50, 93, 0.1), 0 5px 15px rgba(0, 0, 0, 0.07);
+  box-shadow: 0 15px 35px var(--color-card-shadow), 0 5px 15px rgba(0, 0, 0, 0.07);
+  background-color: var(--color-card-bg);
 }
+
 .main-header {
   padding: 1.2rem 1.5rem;
 }
@@ -43,6 +128,68 @@ $fa-font-path: "~font-awesome/fonts";
   padding-bottom: 4em;
 }
 
+/* Hero section theming */
+.hero.is-primary {
+  background-color: var(--hero-bg);
+}
+
+.hero.is-white {
+  background-color: var(--color-bg);
+
+  .title,
+  .subtitle {
+    color: var(--color-text);
+  }
+}
+
+/* Box theming */
+.box {
+  background-color: var(--color-card-bg);
+  color: var(--color-text);
+}
+
+/* Section theming */
+.section {
+  background-color: var(--color-bg);
+}
+
+/* Title and text theming */
+.title {
+  color: var(--color-text);
+}
+
+.subtitle {
+  color: var(--color-text-secondary);
+}
+
+/* Logo glow effect */
+.main-header img {
+  filter: var(--logo-filter);
+  transition: filter 0.3s ease;
+}
+
 .search-pattern {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 304 304' width='304' height='304'%3E%3Cpath fill='%23297eb8' fill-opacity='0.31' d='M44.1 224a5 5 0 1 1 0 2H0v-2h44.1zm160 48a5 5 0 1 1 0 2H82v-2h122.1zm57.8-46a5 5 0 1 1 0-2H304v2h-42.1zm0 16a5 5 0 1 1 0-2H304v2h-42.1zm6.2-114a5 5 0 1 1 0 2h-86.2a5 5 0 1 1 0-2h86.2zm-256-48a5 5 0 1 1 0 2H0v-2h12.1zm185.8 34a5 5 0 1 1 0-2h86.2a5 5 0 1 1 0 2h-86.2zM258 12.1a5 5 0 1 1-2 0V0h2v12.1zm-64 208a5 5 0 1 1-2 0v-54.2a5 5 0 1 1 2 0v54.2zm48-198.2V80h62v2h-64V21.9a5 5 0 1 1 2 0zm16 16V64h46v2h-48V37.9a5 5 0 1 1 2 0zm-128 96V208h16v12.1a5 5 0 1 1-2 0V210h-16v-76.1a5 5 0 1 1 2 0zm-5.9-21.9a5 5 0 1 1 0 2H114v48H85.9a5 5 0 1 1 0-2H112v-48h12.1zm-6.2 130a5 5 0 1 1 0-2H176v-74.1a5 5 0 1 1 2 0V242h-60.1zm-16-64a5 5 0 1 1 0-2H114v48h10.1a5 5 0 1 1 0 2H112v-48h-10.1zM66 284.1a5 5 0 1 1-2 0V274H50v30h-2v-32h18v12.1zM236.1 176a5 5 0 1 1 0 2H226v94h48v32h-2v-30h-48v-98h12.1zm25.8-30a5 5 0 1 1 0-2H274v44.1a5 5 0 1 1-2 0V146h-10.1zm-64 96a5 5 0 1 1 0-2H208v-80h16v-14h-42.1a5 5 0 1 1 0-2H226v18h-16v80h-12.1zm86.2-210a5 5 0 1 1 0 2H272V0h2v32h10.1zM98 101.9V146H53.9a5 5 0 1 1 0-2H96v-42.1a5 5 0 1 1 2 0zM53.9 34a5 5 0 1 1 0-2H80V0h2v34H53.9zm60.1 3.9V66H82v64H69.9a5 5 0 1 1 0-2H80V64h32V37.9a5 5 0 1 1 2 0zM101.9 82a5 5 0 1 1 0-2H128V37.9a5 5 0 1 1 2 0V82h-28.1zm16-64a5 5 0 1 1 0-2H146v44.1a5 5 0 1 1-2 0V18h-26.1zm102.2 270a5 5 0 1 1 0 2H98v14h-2v-16h124.1zM242 149.9V160h16v34h-16v62h48v48h-2v-46h-48v-66h16v-30h-16v-12.1a5 5 0 1 1 2 0zM53.9 18a5 5 0 1 1 0-2H64V2H48V0h18v18H53.9zm112 32a5 5 0 1 1 0-2H192V0h50v2h-48v48h-28.1zm-48-48a5 5 0 0 1-9.8-2h2.07a3 3 0 1 0 5.66 0H178v34h-18V21.9a5 5 0 1 1 2 0V32h14V2h-58.1zm0 96a5 5 0 1 1 0-2H137l32-32h39V21.9a5 5 0 1 1 2 0V66h-40.17l-32 32H117.9zm28.1 90.1a5 5 0 1 1-2 0v-76.51L175.59 80H224V21.9a5 5 0 1 1 2 0V82h-49.59L146 112.41v75.69zm16 32a5 5 0 1 1-2 0v-99.51L184.59 96H300.1a5 5 0 0 1 3.9-3.9v2.07a3 3 0 0 0 0 5.66v2.07a5 5 0 0 1-3.9-3.9H185.41L162 121.41v98.69zm-144-64a5 5 0 1 1-2 0v-3.51l48-48V48h32V0h2v50H66v55.41l-48 48v2.69zM50 53.9v43.51l-48 48V208h26.1a5 5 0 1 1 0 2H0v-65.41l48-48V53.9a5 5 0 1 1 2 0zm-16 16V89.41l-34 34v-2.82l32-32V69.9a5 5 0 1 1 2 0zM12.1 32a5 5 0 1 1 0 2H9.41L0 43.41V40.6L8.59 32h3.51zm265.8 18a5 5 0 1 1 0-2h18.69l7.41-7.41v2.82L297.41 50H277.9zm-16 160a5 5 0 1 1 0-2H288v-71.41l16-16v2.82l-14 14V210h-28.1zm-208 32a5 5 0 1 1 0-2H64v-22.59L40.59 194H21.9a5 5 0 1 1 0-2H41.41L66 216.59V242H53.9zm150.2 14a5 5 0 1 1 0 2H96v-56.6L56.6 162H37.9a5 5 0 1 1 0-2h19.5L98 200.6V256h106.1zm-150.2 2a5 5 0 1 1 0-2H80v-46.59L48.59 178H21.9a5 5 0 1 1 0-2H49.41L82 208.59V258H53.9zM34 39.8v1.61L9.41 66H0v-2h8.59L32 40.59V0h2v39.8zM2 300.1a5 5 0 0 1 3.9 3.9H3.83A3 3 0 0 0 0 302.17V256h18v48h-2v-46H2v42.1zM34 241v63h-2v-62H0v-2h34v1zM17 18H0v-2h16V0h2v18h-1zm273-2h14v2h-16V0h2v16zm-32 273v15h-2v-14h-14v14h-2v-16h18v1zM0 92.1A5.02 5.02 0 0 1 6 97a5 5 0 0 1-6 4.9v-2.07a3 3 0 1 0 0-5.66V92.1zM80 272h2v32h-2v-32zm37.9 32h-2.07a3 3 0 0 0-5.66 0h-2.07a5 5 0 0 1 9.8 0zM5.9 0A5.02 5.02 0 0 1 0 5.9V3.83A3 3 0 0 0 3.83 0H5.9zm294.2 0h2.07A3 3 0 0 0 304 3.83V5.9a5 5 0 0 1-3.9-5.9zm3.9 300.1v2.07a3 3 0 0 0-1.83 1.83h-2.07a5 5 0 0 1 3.9-3.9zM97 100a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm0-16a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm16 16a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm16 16a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm0 16a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm-48 32a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm16 16a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm32 48a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm-16 16a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm32-16a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm0-32a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm16 32a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm32 16a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm0-16a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm-16-64a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm16 0a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm16 96a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm0 16a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm16 16a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm16-144a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm0 32a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm16-32a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm16-16a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm-96 0a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm0 16a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm16-32a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm96 0a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm-16-64a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm16-16a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm-32 0a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm0-16a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm-16 0a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm-16 0a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm-16 0a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM49 36a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm-32 0a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm32 16a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM33 68a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm16-48a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm0 240a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm16 32a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm-16-64a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm0 16a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm-16-32a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm80-176a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm16 0a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm-16-16a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm32 48a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm16-16a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm0-32a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm112 176a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm-16 16a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm0 16a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm0 16a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM17 180a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm0 16a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm0-32a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm16 0a3 3 0 1 0 0-6 3 3 0 0 0 0 6zM17 84a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm32 64a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm16-16a3 3 0 1 0 0-6 3 3 0 0 0 0 6z'%3E%3C/path%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 304 304' width='304' height='304'%3E%3Cpath fill='%23297eb8' fill-opacity='0.31' d='M44.1 224a5 5 0 1 1 0 2H0v-2h44.1zm160 48a5 5 0 1 1 0 2H82v-2h122.1zm57.8-46a5 5 0 1 1 0-2H304v2h-42.1zm0 16a5 5 0 1 1 0-2H304v2h-42.1zm6.2-114a5 5 0 1 1 0 2h-86.2a5 5 0 1 1 0-2h86.2zm-256-48a5 5 0 1 1 0 2H0v-2h12.1zm185.8 34a5 5 0 1 1 0-2h86.2a5 5 0 1 1 0 2h-86.2zM258 12.1a5 5 0 1 1-2 0V0h2v12.1zm-64 208a5 5 0 1 1-2 0v-54.2a5 5 0 1 1 2 0v54.2zm48-198.2V80h62v2h-64V21.9a5 5 0 1 1 2 0zm16 16V64h46v2h-48V37.9a5 5 0 1 1 2 0zm-128 96V208h16v12.1a5 5 0 1 1-2 0V210h-16v-76.1a5 5 0 1 1 2 0zm-5.9-21.9a5 5 0 1 1 0 2H114v48H85.9a5 5 0 1 1 0-2H112v-48h12.1zm-6.2 130a5 5 0 1 1 0-2H176v-74.1a5 5 0 1 1 2 0V242h-60.1zm-16-64a5 5 0 1 1 0-2H114v48h10.1a5 5 0 1 1 0 2H112v-48h-10.1zM66 284.1a5 5 0 1 1-2 0V274H50v30h-2v-32h18v12.1zM236.1 176a5 5 0 1 1 0 2H226v94h48v32h-2v-30h-48v-98h12.1zm25.8-30a5 5 0 1 1 0-2H274v44.1a5 5 0 1 1-2 0V146h-10.1zm-64 96a5 5 0 1 1 0-2H208v-80h16v-14h-42.1a5 5 0 1 1 0-2H226v18h-16v80h-12.1zm86.2-210a5 5 0 1 1 0 2H272V0h2v32h10.1zM98 101.9V146H53.9a5 5 0 1 1 0-2H96v-42.1a5 5 0 1 1 2 0zM53.9 34a5 5 0 1 1 0-2H80V0h2v34H53.9zm60.1 3.9V66H82v64H69.9a5 5 0 1 1 0-2H80V64h32V37.9a5 5 0 1 1 2 0zM101.9 82a5 5 0 1 1 0-2H128V37.9a5 5 0 1 1 2 0V82h-28.1zm16-64a5 5 0 1 1 0-2H146v44.1a5 5 0 1 1-2 0V18h-26.1zm102.2 270a5 5 0 1 1 0 2H98v14h-2v-16h124.1zM242 149.9V160h16v34h-16v62h48v48h-2v-46h-48v-66h16v-30h-16v-12.1a5 5 0 1 1 2 0zM53.9 18a5 5 0 1 1 0-2H64V2H48V0h18v18H53.9zm112 32a5 5 0 1 1 0-2H192V0h50v2h-48v48h-28.1zm-48-48a5 5 0 0 1-9.8-2h2.07a3 3 0 1 0 5.66 0H178v34h-18V21.9a5 5 0 1 1 2 0V32h14V2h-58.1zm0 96a5 5 0 1 1 0-2H137l32-32h39V21.9a5 5 0 1 1 2 0V66h-40.17l-32 32H117.9zm28.1 90.1a5 5 0 1 1-2 0v-76.51L175.59 80H224V21.9a5 5 0 1 1 2 0V82h-49.59L146 112.41v75.69zm16 32a5 5 0 1 1-2 0v-99.51L184.59 96H300.1a5 5 0 0 1 3.9-3.9v2.07a3 3 0 0 0 0 5.66v2.07a5 5 0 0 1-3.9-3.9H185.41L162 121.41v98.69zm-144-64a5 5 0 1 1-2 0v-3.51l48-48V48h32V0h2v50H66v55.41l-48 48v2.69zM50 53.9v43.51l-48 48V208h26.1a5 5 0 1 1 0 2H0v-65.41l48-48V53.9a5 5 0 1 1 2 0zm-16 16V89.41l-34 34v-2.82l32-32V69.9a5 5 0 1 1 2 0zM12.1 32a5 5 0 1 1 0 2H9.41L0 43.41V40.6L8.59 32h3.51zm265.8 18a5 5 0 1 1 0-2h18.69l7.41-7.41v2.82L297.41 50H googlesH277.9zm-16 160a5 5 0 1 1 0-2H288v-71.41l16-16v2.82l-14 14V210h-28.1zm-208 32a5 5 0 1 1 0-2H64v-22.59L40.59 194H21.9a5 5 0 1 1 0-2H41.41L66 216.59V242H googlesH53.9zm150.2 14a5 5 0 1 1 0 2H googlesH96v-56.6L56.6 162H37.9a5 5 0 1 1 0-2h19.5L98 200.6V256h106.1zm-150.2 2a5 5 0 1 1 0-2H80v-46.59L48.59 178H21.9a5 5 0 1 1 0-2H49.41L82 208.59V258H53.9zM34 39.8v1.61L9.41 66H0v-2h8.59L32 40.59V0h2v39.8zM2 300.1a5 5 0 0 1 3.9 3.9H3.83a3 3 0 0 0-1.764-1.775V300.1zm34 0v2.07a3 3 0 0 0 0 5.66v2.07a5 5 0 0 1-3.9-3.9H32v-62h-2v60H0v2h34zm210 0a5 5 0 0 1 3.9-3.9v2.07a3 3 0 0 0 0 5.66v2.07a5 5 0 0 1-3.9-3.9H244v-60h-2v62h10v-2zm-74 58h-2v-18h2v18zM304 0v2h-32v-2h32zm-64 0v2h-32v-2h32zm-96 0v2h-32v-2h32zm-64 0v2H48v-2h32zM40 262l-16 16v2l18-18 40 40 42-42 60 60 12-12 24 24v-2l-22-22 32-32-10-10h2l12 12-36 36 22 22v2l-26-26-10 10-62-62-40 40-20-20 16-16v-2l-18 18 22 22v2l-24-24z'%3E%3C/path%3E%3C/svg%3E");
+}
+
+/* Dark mode pattern overlay - slightly different opacity */
+body.dark-theme .search-pattern {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 304 304' width='304' height='304'%3E%3Cpath fill='%234a9fd4' fill-opacity='0.15' d='M44.1 224a5 5 0 1 1 0 2H0v-2h44.1zm160 48a5 5 0 1 1 0 2H82v-2h122.1zm57.8-46a5 5 0 1 1 0-2H304v2h-42.1zm0 16a5 5 0 1 1 0-2H304v2h-42.1zm6.2-114a5 5 0 1 1 0 2h-86.2a5 5 0 1 1 0-2h86.2zm-256-48a5 5 0 1 1 0 2H0v-2h12.1zm185.8 34a5 5 0 1 1 0-2h86.2a5 5 0 1 1 0 2h-86.2zM258 12.1a5 5 0 1 1-2 0V0h2v12.1zm-64 208a5 5 0 1 1-2 0v-54.2a5 5 0 1 1 2 0v54.2zm48-198.2V80h62v2h-64V21.9a5 5 0 1 1 2 0zm16 16V64h46v2h-48V37.9a5 5 0 1 1 2 0zm-128 96V208h16v12.1a5 5 0 1 1-2 0V210h-16v-76.1a5 5 0 1 1 2 0zm-5.9-21.9a5 5 0 1 1 0 2H114v48H85.9a5 5 0 1 1 0-2H112v-48h12.1zm-6.2 130a5 5 0 1 1 0-2H176v-74.1a5 5 0 1 1 2 0V242h-60.1zm-16-64a5 5 0 1 1 0-2H114v48h10.1a5 5 0 1 1 0 2H112v-48h-10.1zM66 284.1a5 5 0 1 1-2 0V274H50v30h-2v-32h18v12.1zM236.1 176a5 5 0 1 1 0 2H226v94h48v32h-2v-30h-48v-98h12.1zm25.8-30a5 5 0 1 1 0-2H274v44.1a5 5 0 1 1-2 0V146h-10.1zm-64 96a5 5 0 1 1 0-2H208v-80h16v-14h-42.1a5 5 0 1 1 0-2H226v18h-16v80h-12.1zm86.2-210a5 5 0 1 1 0 2H272V0h2v32h10.1zM98 101.9V146H53.9a5 5 0 1 1 0-2H96v-42.1a5 5 0 1 1 2 0zM53.9 34a5 5 0 1 1 0-2H80V0h2v34H53.9zm60.1 3.9V66H82v64H69.9a5 5 0 1 1 0-2H80V64h32V37.9a5 5 0 1 1 2 0zM101.9 82a5 5 0 1 1 0-2H128V37.9a5 5 0 1 1 2 0V82h-28.1zm16-64a5 5 0 1 1 0-2H146v44.1a5 5 0 1 1-2 0V18h-26.1zm102.2 270a5 5 0 1 1 0 2H98v14h-2v-16h124.1zM242 149.9V160h16v34h-16v62h48v48h-2v-46h-48v-66h16v-30h-16v-12.1a5 5 0 1 1 2 0zM53.9 18a5 5 0 1 1 0-2H64V2H48V0h18v18H53.9zm112 32a5 5 0 1 1 0-2H192V0h50v2h-48v48h-28.1zm-48-48a5 5 0 0 1-9.8-2h2.07a3 3 0 1 0 5.66 0H178v34h-18V21.9a5 5 0 1 1 2 0V32h14V2h-58.1zm0 96a5 5 0 1 1 0-2H137l32-32h39V21.9a5 5 0 1 1 2 0V66h-40.17l-32 32H117.9zm28.1 90.1a5 5 0 1 1-2 0v-76.51L175.59 80H224V21.9a5 5 0 1 1 2 0V82h-49.59L146 112.41v75.69zm16 32a5 5 0 1 1-2 0v-99.51L184.59 96H300.1a5 5 0 0 1 3.9-3.9v2.07a3 3 0 0 0 0 5.66v2.07a5 5 0 0 1-3.9-3.9H185.41L162 121.41v98.69zm-144-64a5 5 0 1 1-2 0v-3.51l48-48V48h32V0h2v50H66v55.41l-48 48v2.69zM50 53.9v43.51l-48 48V208h26.1a5 5 0 1 1 0 2H0v-65.41l48-48V53.9a5 5 0 1 1 2 0zm-16 16V89.41l-34 34v-2.82l32-32V69.9a5 5 0 1 1 2 0zM12.1 32a5 5 0 1 1 0 2H9.41L0 43.41V40.6L8.59 32h3.51zm265.8 18a5 5 0 1 1 0-2h18.69l7.41-7.41v2.82L297.41 50H googlesH277.9zm-16 160a5 5 0 1 1 0-2H288v-71.41l16-16v2.82l-14 14V210h-28.1zm-208 32a5 5 0 1 1 0-2H64v-22.59L40.59 194H21.9a5 5 0 1 1 0-2H41.41L66 216.59V242H googlesH53.9zm150.2 14a5 5 0 1 1 0 2H googlesH96v-56.6L56.6 162H37.9a5 5 0 1 1 0-2h19.5L98 200.6V256h106.1zm-150.2 2a5 5 0 1 1 0-2H80v-46.59L48.59 178H21.9a5 5 0 1 1 0-2H49.41L82 208.59V258H53.9zM34 39.8v1.61L9.41 66H0v-2h8.59L32 40.59V0h2v39.8zM2 300.1a5 5 0 0 1 3.9 3.9H3.83a3 3 0 0 0-1.764-1.775V300.1zm34 0v2.07a3 3 0 0 0 0 5.66v2.07a5 5 0 0 1-3.9-3.9H32v-62h-2v60H0v2h34zm210 0a5 5 0 0 1 3.9-3.9v2.07a3 3 0 0 0 0 5.66v2.07a5 5 0 0 1-3.9-3.9H244v-60h-2v62h10v-2zm-74 58h-2v-18h2v18zM304 0v2h-32v-2h32zm-64 0v2h-32v-2h32zm-96 0v2h-32v-2h32zm-64 0v2H48v-2h32zM40 262l-16 16v2l18-18 40 40 42-42 60 60 12-12 24 24v-2l-22-22 32-32-10-10h2l12 12-36 36 22 22v2l-26-26-10 10-62-62-40 40-20-20 16-16v-2l-18 18 22 22v2l-24-24z'%3E%3C/path%3E%3C/svg%3E");
+}
+
+/* Input theming */
+.input,
+.textarea {
+  background-color: var(--color-input-bg);
+  border-color: var(--color-border);
+  color: var(--color-text);
+
+  &::placeholder {
+    color: var(--color-text-muted);
+  }
+}
+
+/* Label theming */
+.label {
+  color: var(--color-text);
 }


### PR DESCRIPTION
## Summary

- Add dark theme support with automatic system preference detection
- Add theme toggle button in the top-right corner cycling through system/light/dark modes
- Persist user preference to localStorage

## Changes

### Theme Infrastructure
- **ThemeService** (`theme.service.ts`): Angular service using signals for reactive theme state
  - Detects system preference via `prefers-color-scheme` media query
  - Listens for system theme changes in real-time
  - Persists user preference to localStorage
  - Provides computed `isDark` signal for reactive updates

- **ThemeToggleComponent** (`theme-toggle.component.ts`): Simple button that cycles through modes
  - Shows current mode icon: desktop (system), sun (light), moon (dark)
  - Positioned fixed top-right with hover animations

### Styling
- Converted hardcoded SCSS variables to CSS custom properties for dynamic theming
- Added `:root` and `.dark-theme` selectors with complete color palettes
- Smooth 0.3s transitions for all color changes
- Dark theme uses navy-based palette (#1a1a2e) complementing the brand blue

### Component Updates
- **Chart.js**: Theme-aware grid lines, text colors, and tooltip styling
- **Footer**: Uses CSS variables for background and text colors  
- **Search components**: Autocomplete and type toggle use theme colors
- **Loading indicator**: Bar chart animation uses theme background color
- **Logo**: Subtle blue glow effect in dark mode via CSS filter

### Sentry Integration
- Updated feedback widget to use `colorScheme: "system"` for auto-detection
- Added `themeDark` accent color matching the dark theme primary

## Screenshots

The dark theme automatically activates based on system preference, or can be manually toggled.

## Testing

- All 62 existing tests pass
- Build succeeds without errors