### PR TITLE
feat: embed app version (git SHA) in frontend footer and backend headers

### DIFF
--- a/.github/workflows/scheduler-workflow.yml
+++ b/.github/workflows/scheduler-workflow.yml
@@ -68,7 +68,7 @@ jobs:
           echo ${{ steps.docker-prep.outputs.created }}
 
       - name: Build
-        run: dotnet build -c Release
+        run: dotnet build -c Release -p:SourceRevisionId=${GITHUB_SHA::8}
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         working-directory: src/NuGetTrends.Scheduler/

--- a/.github/workflows/web-workflow.yml
+++ b/.github/workflows/web-workflow.yml
@@ -108,7 +108,7 @@ jobs:
         uses: codecov/codecov-action@v3
 
       - name: Web Build
-        run: dotnet build -c Release
+        run: dotnet build -c Release -p:SourceRevisionId=${GITHUB_SHA::8}
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         working-directory: src/NuGetTrends.Web/

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,6 +7,8 @@
     <NoWarn>$(NoWarn);1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <SentryVersion>6.0.0</SentryVersion>
+    <!-- Version embedding: set via CI with -p:SourceRevisionId=<sha>, defaults to 'local' for dev -->
+    <SourceRevisionId Condition="'$(SourceRevisionId)' == ''">local</SourceRevisionId>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">

--- a/src/NuGetTrends.Scheduler/Startup.cs
+++ b/src/NuGetTrends.Scheduler/Startup.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Hangfire;
 using Hangfire.Dashboard;
 using Hangfire.MemoryStorage;
@@ -181,10 +182,16 @@ public class Startup(
             db.Database.Migrate();
         }
 
+        // Get app version from assembly (set via SourceRevisionId at build time)
+        var appVersion = Assembly.GetExecutingAssembly()
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion?.Split('+').LastOrDefault() ?? "unknown";
+
         app.UseHangfireDashboard(
             pathMatch: "",
             options: new DashboardOptions
             {
+                DashboardTitle = $"NuGet Trends Scheduler ({appVersion})",
                 Authorization = new IDashboardAuthorizationFilter[]
                 {
                     // Process not expected to be exposed to the internet

--- a/src/NuGetTrends.Web/Portal/src/app/core/footer/footer.component.html
+++ b/src/NuGetTrends.Web/Portal/src/app/core/footer/footer.component.html
@@ -34,5 +34,6 @@
         Hosted by <img src="../../assets/images/sentry-logo.svg" alt="Sentry" class="sentry-logo">
       </a>
     </p>
+    <p class="version-info">{{ version }}</p>
   </div>
 </footer>

--- a/src/NuGetTrends.Web/Portal/src/app/core/footer/footer.component.scss
+++ b/src/NuGetTrends.Web/Portal/src/app/core/footer/footer.component.scss
@@ -43,3 +43,11 @@ footer {
     transition: opacity 0.2s ease;
   }
 }
+
+.version-info {
+  margin-top: 15px;
+  font-size: 11px;
+  color: #b5b5b5;
+  text-align: center;
+  opacity: 0.6;
+}

--- a/src/NuGetTrends.Web/Portal/src/app/core/footer/footer.component.ts
+++ b/src/NuGetTrends.Web/Portal/src/app/core/footer/footer.component.ts
@@ -7,6 +7,6 @@ import { Component } from '@angular/core';
   standalone: false
 })
 export class FooterComponent {
-
   public year = new Date().getFullYear();
+  public version = (window as any).SENTRY_RELEASE?.id ?? 'local';
 }

--- a/src/NuGetTrends.Web/Program.cs
+++ b/src/NuGetTrends.Web/Program.cs
@@ -143,11 +143,18 @@ try
     // Map Aspire health check endpoints
     app.MapDefaultEndpoints();
 
+    // Get app version from assembly (set via SourceRevisionId at build time)
+    var appVersion = Assembly.GetExecutingAssembly()
+        .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+        ?.InformationalVersion?.Split('+').LastOrDefault() ?? "unknown";
+
     app.Use(async (context, next) => {
         context.Response.OnStarting(() => {
             // Sentry Browser Profiling
             // https://docs.sentry.io/platforms/javascript/profiling/
             context.Response.Headers.Append("Document-Policy", "js-profiling");
+            // App version header
+            context.Response.Headers.Append("X-Version", appVersion);
             return Task.CompletedTask;
         });
         await next();


### PR DESCRIPTION
## Summary

- Add `X-Version` response header to Web API with git SHA
- Display version in Angular footer component (subtle gray text)
- Show version in Hangfire dashboard title for Scheduler
- CI workflows pass `SourceRevisionId` to dotnet build
- Local development shows `local` as version

## How it works

| Environment | Frontend Footer | Backend `X-Version` Header | Hangfire Dashboard Title |
|-------------|----------------|---------------------------|-------------------------|
| Local dev | `local` | `local` | `NuGet Trends Scheduler (local)` |
| CI/Production | `abc1234` | `abc1234` | `NuGet Trends Scheduler (abc1234)` |