### PR TITLE
feat: upload source maps to Sentry for SPA

### DIFF
--- a/.github/workflows/web-workflow.yml
+++ b/.github/workflows/web-workflow.yml
@@ -101,6 +101,17 @@ jobs:
         run: npm run build
         working-directory: src/NuGetTrends.Web/Portal
 
+      - name: Upload source maps to Sentry
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: nugettrends
+          SENTRY_PROJECT: spa
+        run: |
+          RELEASE="NuGetTrends.Spa@1.0.0+${GITHUB_SHA}"
+          npx @sentry/cli releases files "$RELEASE" upload-sourcemaps ./dist --url-prefix '~/'
+        working-directory: src/NuGetTrends.Web/Portal
+
       - name: Replace SPA path on coverage file (Hack codecov) # https://community.codecov.io/t/looking-for-assistance-with-path-fixing/1669/9
         run: sed -i 's/SF:/SF:src\/NuGetTrends.Web\/Portal\//g' src/NuGetTrends.Web/Portal/coverage/lcov.info
 

--- a/src/NuGetTrends.Web/Portal/angular.json
+++ b/src/NuGetTrends.Web/Portal/angular.json
@@ -62,6 +62,11 @@
                   "with": "src/environments/environment.prod.ts"
                 }
               ],
+              "sourceMap": {
+                "scripts": true,
+                "styles": false,
+                "hidden": true
+              },
               "optimization": true,
               "outputHashing": "all",
               "namedChunks": false,

--- a/src/NuGetTrends.Web/Portal/package.json
+++ b/src/NuGetTrends.Web/Portal/package.json
@@ -5,7 +5,7 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "npm run generate-release && ng build",
-    "generate-release": "mkdir -p tmp; echo window.SENTRY_RELEASE={id:\\'`git rev-parse --short HEAD`\\'} > tmp/release.js",
+    "generate-release": "mkdir -p tmp; echo window.SENTRY_RELEASE={id:\\'NuGetTrends.Spa@1.0.0+`git rev-parse HEAD`\\'} > tmp/release.js",
     "test-no-watch": "ng test --watch=false",
     "test-cc": "ng test --watch=false --code-coverage"
   },


### PR DESCRIPTION
## Summary

- Enable hidden source maps in production Angular build
- Update release format to match API/Scheduler pattern (`NuGetTrends.Spa@1.0.0+<sha>`)
- Add CI step to upload source maps to Sentry after SPA build

## Changes

### `angular.json`
Added `sourceMap` configuration to production build with `hidden: true` - this generates source maps but doesn't include references in the JS bundles (not publicly accessible).

### `package.json`
Changed release format from `<short-sha>` to `NuGetTrends.Spa@1.0.0+<full-sha>` to match the API/Scheduler release naming convention.

### `web-workflow.yml`
Added "Upload source maps to Sentry" step after the SPA build that:
- Uses `npx @sentry/cli` to upload source maps to the `spa` Sentry project
- Only runs on `main` branch and tags (not PRs)
- Uses the same release format as the frontend SDK

## Related

Companion PR in infra repo to finalize releases during deploy: https://github.com/getsentry/nuget-trends-infra/pull/new/feature/sentry-spa-release