### PR TITLE
fix: update autocomplete dropdown styling for dark theme

### DIFF
--- a/src/NuGetTrends.Web/Portal/src/app/shared/components/search-input/search-input.component.scss
+++ b/src/NuGetTrends.Web/Portal/src/app/shared/components/search-input/search-input.component.scss
@@ -1,9 +1,10 @@
-.mat-autocomplete-panel {
+/* Angular Material 19 MDC-based autocomplete panel styling */
+.mat-mdc-autocomplete-panel {
   font-size: 1.1em;
   color: var(--color-text);
   border: 1px solid var(--color-border);
   border-top: none;
-  background-color: var(--color-autocomplete-bg);
+  background-color: var(--color-autocomplete-bg) !important;
 }
 
 .package-img {
@@ -13,10 +14,16 @@
   margin-right: 8px;
 }
 
-.mat-option:hover:not(.mat-option-disabled),
-.mat-option.mat-active {
-  background-color: var(--color-autocomplete-hover);
-  color: #fff;
+/* MDC option styling */
+.mat-mdc-option {
+  color: var(--color-text);
+}
+
+.mat-mdc-option:hover:not(.mat-mdc-option-disabled),
+.mat-mdc-option.mdc-list-item--selected,
+.mat-mdc-option.mat-mdc-option-active {
+  background-color: var(--color-autocomplete-hover) !important;
+  color: #fff !important;
 }
 
 /* Extra styles to make the input a little nicer on the header */

--- a/src/NuGetTrends.Web/Portal/src/styles.scss
+++ b/src/NuGetTrends.Web/Portal/src/styles.scss
@@ -193,3 +193,19 @@ body.dark-theme .search-pattern {
 .label {
   color: var(--color-text);
 }
+
+/* Angular Material CDK overlay theming for autocomplete */
+.cdk-overlay-container .mat-mdc-autocomplete-panel {
+  background-color: var(--color-autocomplete-bg);
+  color: var(--color-text);
+}
+
+.cdk-overlay-container .mat-mdc-option {
+  color: var(--color-text);
+}
+
+.cdk-overlay-container .mat-mdc-option:hover:not(.mat-mdc-option-disabled),
+.cdk-overlay-container .mat-mdc-option.mdc-list-item--selected,
+.cdk-overlay-container .mat-mdc-option.mat-mdc-option-active {
+  background-color: var(--color-autocomplete-hover);
+}


### PR DESCRIPTION
## Summary

- Fix autocomplete dropdown showing white background in dark mode
- Update Angular Material selectors from legacy to MDC format (Angular Material 19)

## Problem

After PR #328 added dark theme support, the search autocomplete dropdown still showed a white background in dark mode because:
1. Angular Material 19 uses MDC-based components with different class names
2. The existing styles targeted legacy selectors (`.mat-autocomplete-panel`, `.mat-option`)
3. CDK overlays render outside the component tree and need global styling

## Changes

### search-input.component.scss
- Updated `.mat-autocomplete-panel` → `.mat-mdc-autocomplete-panel`
- Updated `.mat-option` → `.mat-mdc-option`
- Added MDC state selectors (`.mdc-list-item--selected`, `.mat-mdc-option-active`)
- Added `!important` to override prebuilt theme specificity

### styles.scss
- Added global CDK overlay theming for the autocomplete panel
- Ensures dropdown respects CSS custom properties for both light and dark themes

## Testing

- Build passes
- All 62 tests pass