### PR TITLE
fix: multiply avgMerge by 7 for weekly totals and add nuget.org link

### DIFF
--- a/src/NuGetTrends.Data/ClickHouse/ClickHouseService.cs
+++ b/src/NuGetTrends.Data/ClickHouse/ClickHouseService.cs
@@ -248,8 +248,8 @@ public class ClickHouseService : IClickHouseService
                 today() - INTERVAL {maxAgeMonths:Int32} MONTH AS age_cutoff
             SELECT
                 cur.package_id AS package_id,
-                toInt64(avgMerge(cur.download_avg)) AS current_downloads,
-                toInt64(avgMerge(prev.download_avg)) AS previous_downloads
+                toInt64(avgMerge(cur.download_avg) * 7) AS current_downloads,
+                toInt64(avgMerge(prev.download_avg) * 7) AS previous_downloads
             FROM weekly_downloads cur
             INNER JOIN weekly_downloads prev
                 ON cur.package_id = prev.package_id

--- a/src/NuGetTrends.Web/Portal/src/app/shared/components/trending-packages/trending-packages.component.html
+++ b/src/NuGetTrends.Web/Portal/src/app/shared/components/trending-packages/trending-packages.component.html
@@ -50,6 +50,16 @@
           </div>
 
           <div class="trending-actions">
+            <button
+              class="button"
+              title="View on NuGet.org"
+              (click)="openNuGetPage(package.packageId); $event.stopPropagation()">
+              <span class="icon">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 512 512" fill="currentColor">
+                  <path d="M378.5 150.5c-31.9 0-57.8 25.9-57.8 57.8s25.9 57.8 57.8 57.8 57.8-25.9 57.8-57.8-25.9-57.8-57.8-57.8zM300.2 350.2c-43.2 0-78.3 35-78.3 78.3s35 78.3 78.3 78.3 78.3-35 78.3-78.3-35-78.3-78.3-78.3zM132.8 5c-70.3 0-127.4 57-127.4 127.4s57 127.4 127.4 127.4 127.3-57.1 127.3-127.4S203.1 5 132.8 5z"/>
+                </svg>
+              </span>
+            </button>
             <a
               *ngIf="package.gitHubUrl"
               [href]="package.gitHubUrl"

--- a/src/NuGetTrends.Web/Portal/src/app/shared/components/trending-packages/trending-packages.component.spec.ts
+++ b/src/NuGetTrends.Web/Portal/src/app/shared/components/trending-packages/trending-packages.component.spec.ts
@@ -90,6 +90,19 @@ describe('TrendingPackagesComponent', () => {
     expect(routerSpy.navigate).toHaveBeenCalledWith(['/packages', 'Newtonsoft.Json']);
   });
 
+  it('should open NuGet.org page in new tab', () => {
+    spyOn(window, 'open');
+    fixture.detectChanges();
+
+    component.openNuGetPage('Newtonsoft.Json');
+
+    expect(window.open).toHaveBeenCalledWith(
+      'https://www.nuget.org/packages/Newtonsoft.Json',
+      '_blank',
+      'noopener,noreferrer'
+    );
+  });
+
   describe('formatGrowthRate', () => {
     it('should format positive growth rate with plus sign', () => {
       expect(component.formatGrowthRate(0.25)).toBe('+25%');

--- a/src/NuGetTrends.Web/Portal/src/app/shared/components/trending-packages/trending-packages.component.ts
+++ b/src/NuGetTrends.Web/Portal/src/app/shared/components/trending-packages/trending-packages.component.ts
@@ -44,6 +44,10 @@ export class TrendingPackagesComponent implements OnInit {
     this.router.navigate(['/packages', packageId]);
   }
 
+  openNuGetPage(packageId: string): void {
+    window.open(`https://www.nuget.org/packages/${packageId}`, '_blank', 'noopener,noreferrer');
+  }
+
   /**
    * Formats the growth rate as a percentage string.
    * Returns '+25%' for positive, '-10%' for negative, or '0%' for zero.


### PR DESCRIPTION
## Summary

- Fix download counts to show weekly totals (avgMerge returns daily average, multiply by 7 for weekly)
- Add NuGet.org button to open package page in new tab
- Clicking row still navigates to NuGet Trends chart page
- Add test for openNuGetPage method

Follows up on #331