### PR TITLE
fix: update sentry-cli command for v3 syntax

### DIFF
--- a/.github/workflows/web-workflow.yml
+++ b/.github/workflows/web-workflow.yml
@@ -109,7 +109,7 @@ jobs:
           SENTRY_PROJECT: spa
         run: |
           RELEASE="NuGetTrends.Spa@1.0.0+${GITHUB_SHA}"
-          npx @sentry/cli releases files "$RELEASE" upload-sourcemaps ./dist --url-prefix '~/'
+          npx @sentry/cli sourcemaps upload --release "$RELEASE" --url-prefix '~/' ./dist
         working-directory: src/NuGetTrends.Web/Portal
 
       - name: Replace SPA path on coverage file (Hack codecov) # https://community.codecov.io/t/looking-for-assistance-with-path-fixing/1669/9


### PR DESCRIPTION
## Summary

Fix the source map upload command for Sentry CLI v3.

## Problem

The `releases files <release> upload-sourcemaps` command was removed in Sentry CLI v3, causing the build to fail:
```
error: unrecognized subcommand 'files'
```

## Solution

Use the new `sourcemaps upload` command with `--release` flag:
```bash
# Old (v2)
sentry-cli releases files "$RELEASE" upload-sourcemaps ./dist --url-prefix '~/'

# New (v3)
sentry-cli sourcemaps upload --release "$RELEASE" --url-prefix '~/' ./dist
```