### PR TITLE
fix: parameterize /packages/:packageId route in Sentry transactions

### DIFF
--- a/src/NuGetTrends.Web/Portal/src/app/app.module.ts
+++ b/src/NuGetTrends.Web/Portal/src/app/app.module.ts
@@ -46,6 +46,13 @@ Sentry.init({
     }),
     Sentry.browserTracingIntegration({
       idleTimeout: 30000,
+      beforeStartSpan: (context) => {
+        return {
+          ...context,
+          // Parameterize the /packages/:packageId route to avoid high-cardinality transaction names
+          name: location.pathname.replace(/^\/packages\/[^/?]+$/, '/packages/:packageId'),
+        };
+      },
     }),
     Sentry.browserProfilingIntegration(),
   ],


### PR DESCRIPTION
## Summary

Fix high-cardinality transaction names in Sentry caused by the new NuGet-style URL route.

## Problem

The new `/packages/:packageId` route (from #325) creates separate transactions for each package ID:
- `/packages/Cordon`
- `/packages/Newtonsoft.Json`
- `/packages/Sentry`

This causes high-cardinality transaction names in Sentry, making it harder to analyze performance data.

## Solution

Use `beforeStartSpan` in the `browserTracingIntegration` to normalize these URLs to `/packages/:packageId`:

```javascript
beforeStartSpan: (context) => {
  return {
    ...context,
    name: location.pathname.replace(/^\/packages\/[^/?]+$/, '/packages/:packageId'),
  };
}
```

The regex specifically matches:
- `/packages/Newtonsoft.Json` -> `/packages/:packageId`
- `/packages/Cordon` -> `/packages/:packageId`

But leaves unchanged:
- `/packages` (base route)
- `/packages?ids=...` (query param route)
- `/` (home)

Fixes the issue shown at: https://nugettrends.sentry.io/insights/frontend/summary/?transaction=%2Fpackages%2FCordon