### PR TITLE
feat: show short SHA in footer with copy to clipboard

### DIFF
--- a/src/NuGetTrends.Web/Portal/src/app/core/footer/footer.component.html
+++ b/src/NuGetTrends.Web/Portal/src/app/core/footer/footer.component.html
@@ -34,6 +34,10 @@
         Hosted by <img src="../../assets/images/sentry-logo.svg" alt="Sentry" class="sentry-logo">
       </a>
     </p>
-    <p class="version-info">{{ version }}</p>
+    <p class="version-info">
+      <span class="version-badge" (click)="copyVersion()" title="Copy to clipboard">
+        {{ shortSha }}
+      </span>
+    </p>
   </div>
 </footer>

--- a/src/NuGetTrends.Web/Portal/src/app/core/footer/footer.component.scss
+++ b/src/NuGetTrends.Web/Portal/src/app/core/footer/footer.component.scss
@@ -51,3 +51,15 @@ footer {
   text-align: center;
   opacity: 0.6;
 }
+
+.version-badge {
+  cursor: pointer;
+  font-family: monospace;
+  padding: 2px 8px;
+  border-radius: 4px;
+  background-color: rgba(255, 255, 255, 0.1);
+
+  &:hover {
+    background-color: rgba(255, 255, 255, 0.2);
+  }
+}

--- a/src/NuGetTrends.Web/Portal/src/app/core/footer/footer.component.ts
+++ b/src/NuGetTrends.Web/Portal/src/app/core/footer/footer.component.ts
@@ -8,5 +8,19 @@ import { Component } from '@angular/core';
 })
 export class FooterComponent {
   public year = new Date().getFullYear();
-  public version = (window as any).SENTRY_RELEASE?.id ?? 'local';
+
+  private readonly devVersion = 'NuGetTrends.Spa@1.0.0+dev';
+
+  get fullVersion(): string {
+    return (window as any).SENTRY_RELEASE?.id ?? this.devVersion;
+  }
+
+  get shortSha(): string {
+    const sha = this.fullVersion.split('+')[1];
+    return sha?.substring(0, 8) ?? 'unknown';
+  }
+
+  copyVersion(): void {
+    navigator.clipboard.writeText(this.fullVersion);
+  }
 }


### PR DESCRIPTION
## Summary

- Display short SHA (8 characters) in the footer instead of the full version string
- Click on the version badge to copy the full version (`NuGetTrends.Spa@1.0.0+<sha>`) to clipboard
- Shows `dev` in development mode (falls back to `NuGetTrends.Spa@1.0.0+dev`)