### PR TITLE
fix: add catch-all route to handle unknown paths gracefully

### DIFF
--- a/src/NuGetTrends.Web/Portal/src/app/app-routes.module.spec.ts
+++ b/src/NuGetTrends.Web/Portal/src/app/app-routes.module.spec.ts
@@ -1,0 +1,90 @@
+import { Location } from '@angular/common';
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { Component } from '@angular/core';
+
+// Stub components for testing routes
+@Component({ selector: 'app-mock-home', template: '<div>Home</div>', standalone: false })
+class MockHomeComponent {}
+
+@Component({ selector: 'app-mock-packages', template: '<div>Packages</div>', standalone: false })
+class MockPackagesComponent {}
+
+describe('AppRoutingModule', () => {
+  let router: Router;
+  let location: Location;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [MockHomeComponent, MockPackagesComponent],
+      imports: [
+        RouterTestingModule.withRoutes([
+          { path: '', component: MockHomeComponent, pathMatch: 'full' },
+          { path: 'packages/:packageId', component: MockPackagesComponent },
+          { path: 'packages', component: MockPackagesComponent },
+          { path: '**', redirectTo: '', pathMatch: 'full' }
+        ])
+      ]
+    }).compileComponents();
+
+    router = TestBed.inject(Router);
+    location = TestBed.inject(Location);
+  });
+
+  it('should navigate to home for empty path', fakeAsync(() => {
+    router.navigate(['']);
+    tick();
+    expect(location.path()).toBe('/');
+  }));
+
+  it('should navigate to packages list', fakeAsync(() => {
+    router.navigate(['packages']);
+    tick();
+    expect(location.path()).toBe('/packages');
+  }));
+
+  it('should navigate to packages with packageId', fakeAsync(() => {
+    router.navigate(['packages', 'Newtonsoft.Json']);
+    tick();
+    expect(location.path()).toBe('/packages/Newtonsoft.Json');
+  }));
+
+  describe('catch-all route', () => {
+    it('should redirect /robots.txt to home', fakeAsync(() => {
+      router.navigate(['robots.txt']);
+      tick();
+      expect(location.path()).toBe('/');
+    }));
+
+    it('should redirect /privacy to home', fakeAsync(() => {
+      router.navigate(['privacy']);
+      tick();
+      expect(location.path()).toBe('/');
+    }));
+
+    it('should redirect /api to home', fakeAsync(() => {
+      router.navigate(['api']);
+      tick();
+      expect(location.path()).toBe('/');
+    }));
+
+    it('should redirect old /package/:id format to home', fakeAsync(() => {
+      router.navigate(['package', 'SomePackage']);
+      tick();
+      expect(location.path()).toBe('/');
+    }));
+
+    it('should redirect arbitrary unknown paths to home', fakeAsync(() => {
+      router.navigate(['some', 'unknown', 'path']);
+      tick();
+      expect(location.path()).toBe('/');
+    }));
+
+    it('should redirect single unknown segment to home', fakeAsync(() => {
+      router.navigate(['nonexistent']);
+      tick();
+      expect(location.path()).toBe('/');
+    }));
+  });
+});

--- a/src/NuGetTrends.Web/Portal/src/app/app-routes.module.ts
+++ b/src/NuGetTrends.Web/Portal/src/app/app-routes.module.ts
@@ -6,7 +6,9 @@ import { HomeComponent } from './home/home.component';
 const routes: Routes = [
   {path: '', component: HomeComponent, pathMatch: 'full'},
   {path: 'packages/:packageId', component: PackagesComponent},
-  {path: 'packages', component: PackagesComponent}
+  {path: 'packages', component: PackagesComponent},
+  // Catch-all route: redirect unknown paths to home instead of throwing NG04002
+  {path: '**', redirectTo: '', pathMatch: 'full'}
 ];
 
 @NgModule({


### PR DESCRIPTION
## Summary

- Add a wildcard route (`**`) that redirects unknown paths to the home page instead of throwing Angular Router `NG04002` errors
- This prevents noisy errors in Sentry from bots requesting `/robots.txt`, users accessing old URLs like `/package/*`, and other non-existent routes

## Problem

The Angular SPA was throwing `NG04002: No route match` errors for any unrecognized path. These errors were being grouped together in Sentry because the stacktrace was entirely within Angular Router internals, making it hard to distinguish between different types of missing routes.

Affected routes included:
- `/robots.txt` (bots/crawlers)
- `/package/...` (old URL format, should be `/packages/...`)
- `/privacy`, `/api`, and other non-existent pages

Fixes SPA-25R