### PR TITLE
fix: capture ClickHouse exceptions in Sentry and exclude driver from in-app frames

### DIFF
--- a/src/NuGetTrends.Scheduler/Program.cs
+++ b/src/NuGetTrends.Scheduler/Program.cs
@@ -59,6 +59,8 @@ public class Program
                         // Disable stacktrace attachment for log events - they only contain
                         // system frames when logged from libraries like Polly/EF Core
                         o.AttachStacktrace = false;
+                        // Mark ClickHouse driver frames as not in-app for cleaner stack traces
+                        o.AddInAppExclude("ClickHouse.Driver");
                         o.SetBeforeSend(e =>
                         {
                             // Handle Polly timeout events - downgrade to warning and add URL tag

--- a/src/NuGetTrends.Scheduler/TrendingPackagesSnapshotRefresher.cs
+++ b/src/NuGetTrends.Scheduler/TrendingPackagesSnapshotRefresher.cs
@@ -85,6 +85,7 @@ public class TrendingPackagesSnapshotRefresher(
         {
             logger.LogError(ex, "Job {JobId}: Failed to refresh trending packages snapshot", jobId);
             transaction.Finish(ex);
+            hub.CaptureException(ex);
             throw;
         }
         finally

--- a/src/NuGetTrends.Web/Program.cs
+++ b/src/NuGetTrends.Web/Program.cs
@@ -46,6 +46,8 @@ try
     builder.WebHost.UseConfiguration(configuration)
         .UseSentry(o =>
         {
+            // Mark ClickHouse driver frames as not in-app for cleaner stack traces
+            o.AddInAppExclude("ClickHouse.Driver");
             o.SetBeforeSend(e =>
             {
                 // Ignore SPA default page middleware errors for POST requests


### PR DESCRIPTION
## Summary
- Add `hub.CaptureException()` to `TrendingPackagesSnapshotRefresher` to ensure ClickHouse errors are reported to Sentry (calling `transaction.Finish(ex)` only marks the transaction as failed, it doesn't capture the exception as an error event)
- Add `AddInAppExclude("ClickHouse.Driver")` to both Scheduler and Web Sentry configurations to clean up stack traces

Fixes #340