### PR TITLE
fix: Hangfire cron monitoring with Sentry

### DIFF
--- a/src/NuGetTrends.Scheduler/JobScheduleConfig.cs
+++ b/src/NuGetTrends.Scheduler/JobScheduleConfig.cs
@@ -1,0 +1,46 @@
+namespace NuGetTrends.Scheduler;
+
+/// <summary>
+/// Shared schedule configuration for Hangfire jobs and Sentry cron monitors.
+/// These values are used by both RecurringJobManagerExtensions (Hangfire scheduling)
+/// and the individual job classes (Sentry monitor configuration) to ensure they stay in sync.
+/// </summary>
+internal static class JobScheduleConfig
+{
+    /// <summary>
+    /// NuGet Catalog Importer - runs hourly to sync new packages from NuGet.org catalog.
+    /// </summary>
+    internal static class CatalogImporter
+    {
+        public const string MonitorSlug = "nuget-catalog-importer";
+        public const int IntervalHours = 1;
+        public const int CheckInMarginMinutes = 5;
+        public const int MaxRuntimeMinutes = 120; // 2 hours
+        public const int FailureIssueThreshold = 2;
+    }
+
+    /// <summary>
+    /// Daily Download Publisher - runs daily at 1 AM UTC to queue package IDs for download count fetching.
+    /// </summary>
+    internal static class DailyDownloadPublisher
+    {
+        public const string MonitorSlug = "daily-download-publisher";
+        public const int RunAtHourUtc = 1;
+        public const int CheckInMarginMinutes = 10;
+        public const int MaxRuntimeMinutes = 60; // 1 hour
+        public const int FailureIssueThreshold = 1; // Alert immediately - no retries configured
+    }
+
+    /// <summary>
+    /// Trending Packages Snapshot Refresher - runs weekly on Monday at 2 AM UTC.
+    /// </summary>
+    internal static class TrendingSnapshotRefresher
+    {
+        public const string MonitorSlug = "trending-packages-snapshot-refresh";
+        public const DayOfWeek RunOnDay = DayOfWeek.Monday;
+        public const int RunAtHourUtc = 2;
+        public const int CheckInMarginMinutes = 10;
+        public const int MaxRuntimeMinutes = 30;
+        public const int FailureIssueThreshold = 2; // Allow 1 retry before alerting
+    }
+}

--- a/src/NuGetTrends.Scheduler/Startup.cs
+++ b/src/NuGetTrends.Scheduler/Startup.cs
@@ -11,6 +11,7 @@ using Polly;
 using Polly.Timeout;
 using RabbitMQ.Client;
 using Sentry.Extensibility;
+using Sentry.Hangfire;
 
 namespace NuGetTrends.Scheduler;
 
@@ -105,9 +106,9 @@ public class Startup(
         // Install: Hangfire.PostgreSql
         // Configure: config.UsePostgreSqlStorage(Configuration.GetConnectionString("HangfireConnection")
         services.AddHangfire(config => config
-                .UseStorage(new MemoryStorage())
-                .UseFilter(new SkipConcurrentExecutionFilter()))
-            .AddSentry();
+            .UseStorage(new MemoryStorage())
+            .UseFilter(new SkipConcurrentExecutionFilter())
+            .UseSentry());
         services.AddHangfireServer();
 
         // Bind NuGet resilience options from configuration


### PR DESCRIPTION
## Summary

Fixes Sentry cron monitoring for Hangfire jobs which was not working due to incorrect integration setup.

### Changes

- **Fixed Hangfire configuration**: Changed from `.AddSentry()` on `IServiceCollection` to `.UseSentry()` on the Hangfire configuration builder (as per [Sentry docs](https://docs.sentry.io/platforms/dotnet/crons/hangfire/))
- **Implemented manual check-ins with upsert**: Replaced `[SentryMonitorSlug]` attributes with `SentrySdk.CaptureCheckIn()` calls that include `configureMonitorOptions` for automatic monitor creation/updates

### Monitor Configurations

| Job | Schedule | Margin | Max Runtime | Alert After |
|-----|----------|--------|-------------|-------------|
| `nuget-catalog-importer` | Hourly | 5 min | 2 hours | 2 failures |
| `daily-download-publisher` | Daily | 10 min | 1 hour | 1 failure |
| `trending-packages-snapshot-refresh` | Weekly | 10 min | 30 min | 2 failures |

### Benefits

- Monitor configuration lives in code (Infrastructure as Code)
- No manual Sentry UI setup required
- Monitors auto-created on first job run
- Proper check-in status tracking (in-progress, ok, error)

### Testing

Verified locally by sending test check-ins to Sentry - all 3 monitors were created successfully with correct configurations:

```
Total monitors: 5

Project: scheduler (ID: 1266316)
  Name: nuget-catalog-importer
  Schedule: [1, 'hour']
  Margin: 5 min, Max Runtime: 120 min
  Env 'development': status=active, lastCheckIn=2026-01-04T16:55:17Z

  Name: daily-download-publisher  
  Schedule: [1, 'day']
  Margin: 10 min, Max Runtime: 60 min
  Env 'development': status=ok, lastCheckIn=2026-01-04T16:55:18Z

  Name: trending-packages-snapshot-refresh
  Schedule: [1, 'week']
  Margin: 10 min, Max Runtime: 30 min
  Env 'development': status=ok, lastCheckIn=2026-01-04T16:55:18Z
```

Closes #339