### PR TITLE
fix: return packages array instead of wrapper object from trending API

### DIFF
--- a/src/NuGetTrends.Web/PackageController.cs
+++ b/src/NuGetTrends.Web/PackageController.cs
@@ -92,6 +92,6 @@ public class PackageController(
         }
 
         var trending = await trendingPackagesCache.GetTrendingPackagesAsync(limit, cancellationToken);
-        return Ok(trending);
+        return Ok(trending.Packages);
     }
 }


### PR DESCRIPTION
## Summary

Fixes the trending packages not showing up in the UI after PR #344 was merged.

## Problem

The `TrendingPackagesCache.GetTrendingPackagesAsync()` was changed to return `TrendingPackagesResponse` (which wraps packages in an object with `Week` and `Packages` properties), but the controller was returning the entire wrapper object to the API.

The frontend expects an array of packages directly:
```typescript
getTrendingPackages(limit: number = 10): Observable<ITrendingPackage[]>
```

But was receiving:
```json
{ "week": "2025-12-22", "packages": [...] }
```

## Fix

Return just the packages array from the controller:
```diff
- return Ok(trending);
+ return Ok(trending.Packages);
```

## Testing

- All 10 backend trending tests pass
- All 89 frontend tests pass