### PR TITLE
fix: correct SPA POST error filter to use SentryExceptions

### DIFF
--- a/src/NuGetTrends.Web/Program.cs
+++ b/src/NuGetTrends.Web/Program.cs
@@ -53,9 +53,12 @@ try
                 // Ignore SPA default page middleware errors for POST requests
                 // The SPA middleware doesn't support POST requests to index.html and this is expected behavior
                 // See: https://nugettrends.sentry.io/issues/4968360400/
-                if (e.Exception is InvalidOperationException &&
-                    e.Message?.Formatted is { } message &&
-                    message.Contains("The SPA default page middleware could not return the default page") &&
+                // Note: We check SentryExceptions instead of Exception because when exceptions are
+                // captured via middleware, the Exception property may be null - the exception data
+                // is stored in the SentryExceptions collection instead.
+                var firstException = e.SentryExceptions?.FirstOrDefault();
+                if (firstException?.Type == "System.InvalidOperationException" &&
+                    firstException.Value?.Contains("The SPA default page middleware could not return the default page") == true &&
                     e.Request?.Method == "POST")
                 {
                     return null;


### PR DESCRIPTION
## Summary

- Fix the `SetBeforeSend` filter that was supposed to suppress SPA POST errors but wasn't working
- The filter checked `e.Exception` which is `null` when exceptions are captured via middleware
- Changed to check `e.SentryExceptions` collection which contains the actual exception data

## Root Cause

When exceptions are captured via Sentry's middleware (`SentryMiddleware.UnhandledException`), the `SentryEvent.Exception` property is `null`. The exception information is stored in `e.SentryExceptions` instead, which is the serialized exception data.

The original filter:
```csharp
if (e.Exception is InvalidOperationException && ...)
```

The fixed filter:
```csharp
var firstException = e.SentryExceptions?.FirstOrDefault();
if (firstException?.Type == "System.InvalidOperationException" && ...)
```

Fixes API-3Z