### PR TITLE
fix: batch catalog leaf processing to avoid N+1 queries

### DIFF
--- a/src/NuGet.Protocol.Catalog/ICatalogLeafProcessor.cs
+++ b/src/NuGet.Protocol.Catalog/ICatalogLeafProcessor.cs
@@ -34,4 +34,17 @@ public interface ICatalogLeafProcessor
     /// <param name="token"></param>
     /// <returns>True, if the leaf was successfully processed. False, otherwise.</returns>
     Task ProcessPackageDeleteAsync(PackageDeleteCatalogLeaf leaf, CancellationToken token);
+
+    /// <summary>
+    /// Process a batch of catalog leaves containing package details. This method allows for efficient batch
+    /// processing to avoid N+1 query patterns. The default implementation falls back to processing each leaf
+    /// individually via <see cref="ProcessPackageDetailsAsync"/>.
+    /// </summary>
+    /// <param name="leaves">The batch of leaf documents to process.</param>
+    /// <param name="token">Cancellation token.</param>
+    Task ProcessPackageDetailsBatchAsync(IReadOnlyList<PackageDetailsCatalogLeaf> leaves, CancellationToken token)
+    {
+        // Default implementation processes leaves individually for backward compatibility
+        return Task.WhenAll(leaves.Select(leaf => ProcessPackageDetailsAsync(leaf, token)));
+    }
 }


### PR DESCRIPTION
Resolves: SCHEDULER-XH

## Summary

- Fixes N+1 query pattern detected by Sentry in catalog import process (SCHEDULER-XH)
- Batches package existence checks into a single query instead of individual queries per package
- Reduces database roundtrips from ~50 to 2 per batch of 25 packages (~96% reduction)

## Changes

- Added `ProcessPackageDetailsBatchAsync` to `ICatalogLeafProcessor` interface with default implementation for backward compatibility
- Implemented batch processing in `CatalogLeafProcessor` that:
  - Queries existing packages in a single database call
  - Uses in-memory HashSet for efficient duplicate detection
  - Falls back to individual processing on race condition conflicts
- Updated `CatalogProcessor` to collect package details and process them as a batch
- Added 5 new tests covering batch processing scenarios

## Performance Impact

| Metric | Before | After |
|--------|--------|-------|
| DB queries per batch | ~50 | 2 |
| Roundtrip reduction | - | ~96% |