### PR TITLE
fix: add 3-second timeout to trending packages API call

### DIFF
--- a/src/NuGetTrends.Web/Portal/src/app/core/services/packages.service.ts
+++ b/src/NuGetTrends.Web/Portal/src/app/core/services/packages.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../../../environments/environment';
-import { Observable, map, catchError, of } from 'rxjs';
+import { Observable, map, catchError, of, timeout } from 'rxjs';
 
 import { IPackageSearchResult, IPackageDownloadHistory, ITrendingPackage } from '../../shared/models/package-models';
 
@@ -50,6 +50,8 @@ export class PackagesService {
    * Returns packages that are relatively new (up to 1 year old) with significant downloads.
    */
   getTrendingPackages(limit: number = 10): Observable<ITrendingPackage[]> {
-    return this.httpClient.get<ITrendingPackage[]>(`${this.baseUrl}/package/trending?limit=${limit}`);
+    return this.httpClient.get<ITrendingPackage[]>(`${this.baseUrl}/package/trending?limit=${limit}`).pipe(
+      timeout(3000)
+    );
   }
 }


### PR DESCRIPTION
## Summary

- Add a 3-second client-side timeout to the trending packages HTTP call
- If it doesn't load in time, show the error state and let users search for packages instead of staring at a spinner

## Test plan

- [ ] CI build passes
- [ ] Verify trending packages load normally when API responds quickly
- [ ] Verify error message appears if API takes longer than 3 seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)