### PR TITLE
feat: add /address-review skill for PR comment triage

### DIFF
--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -49,7 +49,7 @@ For **each** comment, do ALL of the following:
    ```
 3. **Reply** explaining what you changed:
    ```bash
-   gh api repos/{owner}/{repo}/pulls/$ARGUMENTS/comments -f body="..." -f in_reply_to_id={comment_id}
+   gh api repos/{owner}/{repo}/pulls/$ARGUMENTS/comments -f body="..." -F in_reply_to={comment_id}
    ```
 4. **Resolve the thread**:
    ```bash
@@ -63,7 +63,7 @@ For **each** comment, do ALL of the following:
    ```
 2. **Reply** explaining why the feedback was rejected with a clear, respectful rationale:
    ```bash
-   gh api repos/{owner}/{repo}/pulls/$ARGUMENTS/comments -f body="..." -f in_reply_to_id={comment_id}
+   gh api repos/{owner}/{repo}/pulls/$ARGUMENTS/comments -f body="..." -F in_reply_to={comment_id}
    ```
 3. **Resolve the thread**:
    ```bash
@@ -84,10 +84,19 @@ If any code changes were made:
 
 ## Step 5: Summary
 
-After processing all comments, provide a summary table:
+After processing all comments, post a summary as a PR comment and also display it to the user:
+
+```bash
+gh pr comment $ARGUMENTS --body "$(cat <<'EOF'
+## Review comments addressed
 
 | # | Comment | Author | Verdict | Action |
 |---|---------|--------|---------|--------|
+| 1 | ... | ... | ... | ... |
+
+EOF
+)"
+```
 
 ## Important rules
 


### PR DESCRIPTION
## Summary
- Adds `.claude/skills/address-review/SKILL.md` — a slash command invoked as `/address-review <pr-number>`
- Processes every review comment (bots and humans): reads the comment, reads the relevant code, assesses validity
- For each comment: replies with rationale, reacts (thumbs-up = accepted, thumbs-down = rejected), and resolves the thread
- If changes are accepted, makes the code fix, commits, and pushes to the PR branch

## Usage
```
/address-review 395
```

## Test plan
- [ ] Review the skill content below
- [ ] Test against a PR with mixed bot/human comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)