### PR TITLE
fix: allow git and dotnet build in address-review skill

### DIFF
--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -9,6 +9,19 @@ allowed-tools: Bash(gh *), Bash(git add *), Bash(git commit *), Bash(git push *)
 
 You are addressing code review comments on PR #$ARGUMENTS.
 
+## Step 0: Wait for reviews to arrive
+
+Bot reviewers (Copilot, Sentry, Codex, etc.) take time to post their comments after a commit is pushed. Before processing, wait until reviews have landed:
+
+1. Check the timestamp of the latest commit on the PR:
+   ```bash
+   gh pr view $ARGUMENTS --json commits --jq '.commits[-1].committedDate'
+   ```
+2. If less than 5 minutes have passed since that commit, wait and re-check for new comments periodically (every 30–60 seconds).
+3. Once 5 minutes have passed since the last commit with no new comments arriving, proceed to Step 1.
+
+This ensures you don't start processing before all reviewers have had a chance to comment.
+
 ## Step 1: Gather context
 
 Fetch the PR details and all review comments:


### PR DESCRIPTION
## Summary
- Adds `git add`, `git commit`, `git push`, and `dotnet build` to the `allowed-tools` in the address-review skill so the full review workflow runs without individual approval prompts

## Test plan
- [ ] Run `/address-review <pr-number>` and verify git/build commands execute without prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)