### PR TITLE
fix: address container publish review comments

### DIFF
--- a/.github/workflows/scheduler-workflow.yml
+++ b/.github/workflows/scheduler-workflow.yml
@@ -71,5 +71,5 @@ jobs:
           dotnet publish --no-build -c Release
           /t:PublishContainer
           -p:ContainerRegistry=docker.io
-          -p:ContainerImageTags='"${{ steps.tags.outputs.tags }}"'
+          -p:ContainerImageTags='${{ steps.tags.outputs.tags }}'
         working-directory: src/NuGetTrends.Scheduler/

--- a/.github/workflows/web-workflow.yml
+++ b/.github/workflows/web-workflow.yml
@@ -70,5 +70,5 @@ jobs:
           dotnet publish --no-build -c Release
           /t:PublishContainer
           -p:ContainerRegistry=docker.io
-          -p:ContainerImageTags='"${{ steps.tags.outputs.tags }}"'
+          -p:ContainerImageTags='${{ steps.tags.outputs.tags }}'
         working-directory: src/NuGetTrends.Web/

--- a/src/NuGetTrends.Scheduler/NuGetTrends.Scheduler.csproj
+++ b/src/NuGetTrends.Scheduler/NuGetTrends.Scheduler.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>true</ImplicitUsings>
     <ContainerRepository>nugettrends/nugettrends.scheduler</ContainerRepository>
+    <ContainerWorkingDirectory>/App</ContainerWorkingDirectory>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NuGetTrends.Web/NuGetTrends.Web.csproj
+++ b/src/NuGetTrends.Web/NuGetTrends.Web.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <ContainerRepository>nugettrends/nugettrends.web</ContainerRepository>
+    <ContainerWorkingDirectory>/App</ContainerWorkingDirectory>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Remove literal `"` from `ContainerImageTags` values in both workflows — the `'"..."'` quoting was passing double-quote characters into MSBuild, producing invalid Docker tag names (e.g. `"main` instead of `main`)
- Add `ContainerWorkingDirectory=/App` to both csproj files — the deleted Dockerfiles had `WORKDIR /App` but the SDK defaults to `/app` (lowercase), which would break the K8s deployment that sets `ASPNETCORE_CONTENTROOT=/App`

Addresses review comments from #404.

## Test plan
- [ ] CI passes (build step)
- [ ] Verify `dotnet publish /t:PublishContainer` produces tags without literal quote chars
- [ ] Verify container image uses `/App` as working directory (matches K8s config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)