### PR TITLE
fix: quote ContainerImageTags to prevent MSBuild semicolon splitting

### DIFF
--- a/.github/workflows/scheduler-workflow.yml
+++ b/.github/workflows/scheduler-workflow.yml
@@ -71,5 +71,5 @@ jobs:
           dotnet publish --no-build -c Release
           /t:PublishContainer
           -p:ContainerRegistry=docker.io
-          -p:ContainerImageTags='${{ steps.tags.outputs.tags }}'
+          "-p:ContainerImageTags=${{ steps.tags.outputs.tags }}"
         working-directory: src/NuGetTrends.Scheduler/

--- a/.github/workflows/web-workflow.yml
+++ b/.github/workflows/web-workflow.yml
@@ -70,5 +70,5 @@ jobs:
           dotnet publish --no-build -c Release
           /t:PublishContainer
           -p:ContainerRegistry=docker.io
-          -p:ContainerImageTags='${{ steps.tags.outputs.tags }}'
+          "-p:ContainerImageTags=${{ steps.tags.outputs.tags }}"
         working-directory: src/NuGetTrends.Web/


### PR DESCRIPTION
## Summary
- The semicolon in `ContainerImageTags` (e.g. `main;sha-90fe6ee1`) was interpreted by MSBuild as a property delimiter, causing the second tag to be treated as an invalid switch (`error MSB1006`)
- Wraps the `-p:ContainerImageTags=...` argument in double quotes so the entire value is passed as a single property
- Fixes both `scheduler-workflow.yml` and `web-workflow.yml`

## Test plan
- [ ] Verify the scheduler and web CI workflows pass on this PR
- [ ] Verify a push to `main` successfully publishes container images with multiple tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)