### PR TITLE
fix: add trailing slash to ContainerWorkingDirectory

### DIFF
--- a/src/NuGetTrends.Scheduler/NuGetTrends.Scheduler.csproj
+++ b/src/NuGetTrends.Scheduler/NuGetTrends.Scheduler.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>true</ImplicitUsings>
     <ContainerRepository>nugettrends/nugettrends.scheduler</ContainerRepository>
-    <ContainerWorkingDirectory>/App</ContainerWorkingDirectory>
+    <ContainerWorkingDirectory>/App/</ContainerWorkingDirectory>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NuGetTrends.Web/NuGetTrends.Web.csproj
+++ b/src/NuGetTrends.Web/NuGetTrends.Web.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <ContainerRepository>nugettrends/nugettrends.web</ContainerRepository>
-    <ContainerWorkingDirectory>/App</ContainerWorkingDirectory>
+    <ContainerWorkingDirectory>/App/</ContainerWorkingDirectory>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- .NET 10 SDK's `PublishContainer` target concatenates `ContainerWorkingDirectory` with the assembly name without a path separator
- This produces a broken entrypoint like `dotnet /AppNuGetTrends.Web.dll` instead of `dotnet /App/NuGetTrends.Web.dll`
- Adds a trailing `/` to `ContainerWorkingDirectory` in both Web and Scheduler csproj files

## Test plan
- [ ] `docker inspect` the built image and verify the entrypoint is `["dotnet", "/App/NuGetTrends.Web.dll"]`
- [ ] Verify the container starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)