### PR TITLE
feat: add Sentry Browser JS SDK to catch WASM boot failures

### DIFF
--- a/src/NuGetTrends.Web/Components/App.razor
+++ b/src/NuGetTrends.Web/Components/App.razor
@@ -89,7 +89,7 @@
             Sentry.init({
                 tunnel: "/t",
                 integrations: [Sentry.replayIntegration()],
-                replaysSessionSampleRate: 0.1,
+                replaysSessionSampleRate: 0,
                 replaysOnErrorSampleRate: 1.0,
             });
         });


### PR DESCRIPTION
## Summary

- Adds the Sentry JS SDK loader (`spa` project, DSN from the old Angular config) before the Blazor bootstrap script so JavaScript errors are captured even when WASM fails to initialize
- Adds `.catch()` to `Blazor.start()` that logs and reports initialization failures to Sentry
- Uses the `/t` tunnel to avoid ad-blockers

## Context

On staging, buttons render via SSR pre-rendering but are inert because WASM doesn't hydrate. With no JS-level error reporter, these failures were invisible — the Blazor .NET Sentry SDK only initializes after WASM boots, so it can't catch boot failures.

## Test plan

- [ ] Deploy to staging and check the `spa` project in Sentry for new errors
- [ ] Verify the WASM loading bar behavior (completes on success, logs error on failure)
- [ ] Confirm the tunnel (`/t`) works for the JS SDK events

🤖 Generated with [Claude Code](https://claude.com/claude-code)