### PR TITLE
fix: set Sentry JS SDK environment from ASPNETCORE_ENVIRONMENT

### DIFF
--- a/src/NuGetTrends.Web/Components/App.razor
+++ b/src/NuGetTrends.Web/Components/App.razor
@@ -88,6 +88,7 @@
         Sentry.onLoad(function() {
             Sentry.init({
                 tunnel: "/t",
+                environment: "@_environment",
                 integrations: [Sentry.replayIntegration()],
                 replaysSessionSampleRate: 0,
                 replaysOnErrorSampleRate: 1.0,
@@ -120,8 +121,11 @@
 
 </html>
 
+@inject IWebHostEnvironment Environment
+
 @code {
     private string _appVersion = "unknown";
+    private string _environment => Environment.EnvironmentName.ToLowerInvariant();
 
     protected override void OnInitialized()
     {


### PR DESCRIPTION
## Summary

- Injects `IWebHostEnvironment` into `App.razor` and server-renders the environment name (lowercased) into the `Sentry.init()` call
- Events from staging will now have `environment: "staging"` instead of the default `"production"`

## Test plan

- [ ] Deploy to staging, trigger an error, verify it appears in Sentry with `environment:staging`

🤖 Generated with [Claude Code](https://claude.com/claude-code)