### PR TITLE
Fix health check endpoints not mapped in staging/production

### DIFF
--- a/src/NuGetTrends.ServiceDefaults/Extensions.cs
+++ b/src/NuGetTrends.ServiceDefaults/Extensions.cs
@@ -97,19 +97,14 @@ public static class Extensions
     /// </summary>
     public static WebApplication MapDefaultEndpoints(this WebApplication app)
     {
-        // Adding health checks endpoints to applications in non-development environments has security implications.
-        // See https://aka.ms/dotnet/aspire/healthchecks for details before enabling these endpoints in non-development environments.
-        if (app.Environment.IsDevelopment())
-        {
-            // All health checks must pass for app to be considered ready to accept traffic after starting
-            app.MapHealthChecks("/health");
+        // All health checks must pass for app to be considered ready to accept traffic after starting
+        app.MapHealthChecks("/health");
 
-            // Only health checks tagged with the "live" tag must pass for app to be considered alive
-            app.MapHealthChecks("/alive", new HealthCheckOptions
-            {
-                Predicate = r => r.Tags.Contains("live")
-            });
-        }
+        // Only health checks tagged with the "live" tag must pass for app to be considered alive
+        app.MapHealthChecks("/alive", new HealthCheckOptions
+        {
+            Predicate = r => r.Tags.Contains("live")
+        });
 
         return app;
     }


### PR DESCRIPTION
## Summary
- The Aspire template default wraps `MapHealthChecks` in an `IsDevelopment()` guard, so `/health` and `/alive` endpoints were never registered in staging/production
- Kubernetes probe requests to `/health` fell through to the SPA `{*catchAll}` route, causing `Headers are read-only, response has already started` exceptions (1,389 occurrences on staging)
- Removed the environment check so health endpoints are mapped in all environments

Fixes API-5R

## Test plan
- [ ] Deploy to staging and verify `/health` returns 200
- [ ] Verify `/alive` returns 200
- [ ] Confirm no new `InvalidOperationException` errors in Sentry

🤖 Generated with [Claude Code](https://claude.com/claude-code)