### PR TITLE
fix: resolve frameworks chart NaN tooltips, wrong dates, and relative mode issues

### DIFF
--- a/src/NuGetTrends.Web.Client/Pages/Frameworks.razor
+++ b/src/NuGetTrends.Web.Client/Pages/Frameworks.razor
@@ -318,7 +318,7 @@
                     }
                     : new TooltipX
                     {
-                        Formatter = @"function(value) { return 'Month ' + value; }",
+                        Formatter = @"function(value) { return 'Month ' + Math.round(value); }",
                     },
                 Y = new TooltipY
                 {


### PR DESCRIPTION
## Summary

- **Fix NaN/undefined tooltips and "2001" X-axis labels in absolute mode**: Replace `.NET DateTime.Ticks` (which exceed JS `Number.MAX_SAFE_INTEGER`) with Unix epoch milliseconds via a new `ToJsTimestamp()` helper
- **Fix tooltip formatters**: Add null/NaN guards to Y-axis and tooltip Y formatters, and add tooltip X formatters (`MMM yyyy` for absolute mode, `Month N` for relative mode)
- **Improve relative mode X-axis**: Add `TickAmount = 10` to limit tick density and a label formatter to round values to integers

## Test plan

- [ ] Run the app locally and navigate to `/frameworks`
- [ ] **Absolute mode**: Verify X-axis shows proper year labels, tooltip header shows formatted date (e.g. "Jan 2023"), tooltip values show formatted numbers (no NaN)
- [ ] **Relative mode**: Verify X-axis shows integer month labels, tooltip header shows "Month N", tooltip values show formatted numbers
- [ ] Test both "By Family" and "Individual TFMs" views in both time modes
- [ ] Verify theme switching still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)