### PR TITLE
fix: correct hover selecting wrong line in Relative mode on frameworks chart

### DIFF
--- a/src/NuGetTrends.Web.Client/Pages/Frameworks.razor
+++ b/src/NuGetTrends.Web.Client/Pages/Frameworks.razor
@@ -311,6 +311,8 @@
             Tooltip = new Tooltip
             {
                 Theme = ThemeState.IsDark ? Mode.Dark : Mode.Light,
+                Shared = _timeMode == TfmTimeMode.Absolute,
+                Intersect = _timeMode != TfmTimeMode.Absolute,
                 X = _timeMode == TfmTimeMode.Absolute
                     ? new TooltipX
                     {


### PR DESCRIPTION
## Summary
- Fixes the frameworks chart hover in Relative mode always selecting the bottom line instead of the line under the cursor
- Sets `Tooltip.Shared = false` and `Tooltip.Intersect = true` for numeric X-axis mode so ApexCharts uses pixel-proximity detection instead of data-space distance, which incorrectly resolved to the series with the smallest Y values
- Calendar Dates (Absolute) mode is unchanged

## Test plan
- [ ] Open /frameworks, switch to Relative mode, hover different lines and verify the correct line is highlighted
- [ ] Verify Calendar Dates mode still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)