### PR TITLE
chore: remove UnoptimizedAssemblyDetector package

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,7 +27,6 @@
     <PackageVersion Include="Serilog.Settings.Configuration" Version="8.0.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="5.0.1" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-    <PackageVersion Include="UnoptimizedAssemblyDetector" Version="0.1.1" />
     <!-- Blazor packages -->
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.0" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -18,8 +18,4 @@
     <!-- <SentryUploadSources>true</SentryUploadSources> -->
     <EmbedAllSources>true</EmbedAllSources>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="UnoptimizedAssemblyDetector" PrivateAssets="All" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Remove the `UnoptimizedAssemblyDetector` package reference from `src/Directory.Build.props` and `Directory.Packages.props`

## Test plan
- [ ] Verify the solution builds successfully without the package

🤖 Generated with [Claude Code](https://claude.com/claude-code)