### PR TITLE
fix: increase font size for chart labels on frameworks page

### DIFF
--- a/src/NuGetTrends.Web.Client/Pages/Frameworks.razor
+++ b/src/NuGetTrends.Web.Client/Pages/Frameworks.razor
@@ -278,7 +278,7 @@
                 FontFamily = "inherit",
                 ForeColor = textColor,
             },
-            Legend = new Legend { Show = true, Position = LegendPosition.Top },
+            Legend = new Legend { Show = true, Position = LegendPosition.Top, FontSize = "14px" },
             Markers = new Markers
             {
                 Size = 4,
@@ -308,7 +308,7 @@
                             Month = "MMM yyyy",
                             Year = "yyyy",
                         },
-                        Style = new AxisLabelStyle { Colors = new Color(textColor) },
+                        Style = new AxisLabelStyle { Colors = new Color(textColor), FontSize = "13px" },
                     },
                     AxisBorder = new AxisBorder { Color = gridColor },
                     AxisTicks = new AxisTicks { Color = gridColor },
@@ -320,7 +320,7 @@
                     TickAmount = 10,
                     Labels = new XAxisLabels
                     {
-                        Style = new AxisLabelStyle { Colors = new Color(textColor) },
+                        Style = new AxisLabelStyle { Colors = new Color(textColor), FontSize = "13px" },
                         Formatter = @"function(val) { return Math.round(val); }",
                     },
                     AxisBorder = new AxisBorder { Color = gridColor },
@@ -332,7 +332,7 @@
                 {
                     Labels = new YAxisLabels
                     {
-                        Style = new AxisLabelStyle { Colors = new Color(textColor) },
+                        Style = new AxisLabelStyle { Colors = new Color(textColor), FontSize = "13px" },
                         Formatter = "function(val) { return val != null && !isNaN(val) ? val.toLocaleString() : ''; }",
                     },
                 },


### PR DESCRIPTION
## Summary
- Increased legend font size (TFM names like `net48`, `net8.0`) from default ~11-12px to **14px**
- Increased axis label font sizes (X and Y axes) to **13px** for better readability

## Screenshot

![Frameworks page with larger chart labels](https://github.com/user-attachments/assets/placeholder)

## Test plan
- [ ] Open the Frameworks page
- [ ] Verify TFM names in the chart legend are visibly larger and readable
- [ ] Verify axis labels (dates and values) are also larger
- [ ] Check both Calendar Dates and Relative modes
- [ ] Check both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)