### PR TITLE
fix: preserve Blazored.Toast from IL trimmer in Release builds

### DIFF
--- a/src/NuGetTrends.Web.Client/TrimmerRoots.xml
+++ b/src/NuGetTrends.Web.Client/TrimmerRoots.xml
@@ -6,4 +6,10 @@
   <assembly fullname="NuGetTrends.Web.Client">
     <type fullname="NuGetTrends.Web.Client.Routes" preserve="all" />
   </assembly>
+
+  <!--
+    Blazored.Toast's IToastService is injected into MainLayout.
+    The trimmer strips its implementation in TrimMode=full, causing CtorNotLocated at runtime.
+  -->
+  <assembly fullname="Blazored.Toast" preserve="all" />
 </linker>


### PR DESCRIPTION
## Summary
- The IL trimmer (`TrimMode=full`) strips `Blazored.Toast` internals in Release builds, causing a `CtorNotLocated` error when the DI container tries to instantiate `MainLayout` (which injects `IToastService`)
- This completely breaks the site in staging/production — the WASM app loads but fails to render any component
- Fix: add `Blazored.Toast` to `TrimmerRoots.xml` to preserve it from trimming

## Test plan
- [x] Verified staging reproduces the `CtorNotLocated` error via headless browser
- [x] Clean Release build succeeds with 0 errors
- [x] Local Release build loads with zero console errors and full page render

🤖 Generated with [Claude Code](https://claude.com/claude-code)