### PR TITLE
fix: preserve entire Web.Client assembly from IL trimmer

### DIFF
--- a/src/NuGetTrends.Web.Client/TrimmerRoots.xml
+++ b/src/NuGetTrends.Web.Client/TrimmerRoots.xml
@@ -1,15 +1,10 @@
 <linker>
   <!--
-    Routes is the WASM root component, referenced only from the server's App.razor.
-    The IL trimmer can't see that cross-project reference, so preserve it explicitly.
+    Preserve the entire client assembly: the IL trimmer in TrimMode=full strips
+    constructor metadata from Razor components (e.g. MainLayout), causing
+    CtorNotLocated at runtime after dotnet publish. This only manifests in
+    published builds since dotnet run/build doesn't trigger trimming.
   -->
-  <assembly fullname="NuGetTrends.Web.Client">
-    <type fullname="NuGetTrends.Web.Client.Routes" preserve="all" />
-  </assembly>
-
-  <!--
-    Blazored.Toast's IToastService is injected into MainLayout.
-    The trimmer strips its implementation in TrimMode=full, causing CtorNotLocated at runtime.
-  -->
+  <assembly fullname="NuGetTrends.Web.Client" preserve="all" />
   <assembly fullname="Blazored.Toast" preserve="all" />
 </linker>


### PR DESCRIPTION
## Summary
- The previous trimmer fix (#443) only preserved `Routes` and `Blazored.Toast`, but `TrimMode=full` also strips constructor metadata from Razor components like `MainLayout`, causing `CtorNotLocated` at runtime
- This only manifests in `dotnet publish` (which triggers IL trimming), **not** in `dotnet run -c Release` — which is why local testing passed but staging was broken
- Fix: preserve the entire `NuGetTrends.Web.Client` assembly since it's the app's own code and should never be trimmed
- Adds a **Native AOT Trimming Check** CI workflow that publishes with trimming, starts the binary, and verifies Blazor WASM renders via headless Playwright — catches regressions like this automatically

## Test plan
- [x] `dotnet publish -c Release` produces 186KB client WASM (was 22KB trimmed)
- [x] Headless browser test against published build: zero errors, correct title, full page render
- [x] Same test against broken (pre-fix) published build: correctly fails with `CtorNotLocated`
- [x] Confirmed staging currently reproduces `CtorNotLocated` with deployed commit `ee711a8c`