### PR TITLE
feat: show git branch name instead of 'local' in footer

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -16,8 +16,11 @@
     <Exec Command="git rev-parse --abbrev-ref HEAD" ConsoleToMSBuild="true" StandardOutputImportance="low" IgnoreExitCode="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="_GitBranch" />
     </Exec>
+    <Exec Condition="'$(_GitBranch)' == 'HEAD'" Command="git rev-parse --short HEAD" ConsoleToMSBuild="true" StandardOutputImportance="low" IgnoreExitCode="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="_GitBranch" />
+    </Exec>
     <PropertyGroup>
-      <SourceRevisionId Condition="'$(_GitBranch)' != ''">$(_GitBranch)</SourceRevisionId>
+      <SourceRevisionId Condition="'$(_GitBranch)' != '' and '$(_GitBranch)' != 'HEAD'">$(_GitBranch)</SourceRevisionId>
     </PropertyGroup>
   </Target>
 

--- a/src/NuGetTrends.Web.Client/Shared/Footer.razor
+++ b/src/NuGetTrends.Web.Client/Shared/Footer.razor
@@ -57,7 +57,8 @@
         _feVersion = infoVersion ?? "unknown";
         var feParts = _feVersion.Split('+');
         var feSha = feParts.Length > 1 ? feParts[^1] : _feVersion;
-        _shortFeSha = feSha.Length > 8 ? feSha[..8] : feSha;
+        var isSha = feSha.Length > 8 && feSha.All(c => char.IsAsciiHexDigit(c));
+        _shortFeSha = isSha ? feSha[..8] : feSha;
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)


### PR DESCRIPTION
## Summary
- Adds an MSBuild target that runs `git rev-parse --abbrev-ref HEAD` during local dev builds
- The footer version badge now displays the current branch name (e.g. `feat/my-feature`) instead of the static `local` placeholder
- CI builds that pass `-p:SourceRevisionId=<sha>` are unaffected

## Test plan
- [x] Verified locally: footer shows `main` on main branch, `feat/footer-branch-name` after checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)