### PR TITLE
docs: remove hardcoded Aspire Dashboard port from docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ This starts:
 
 ### Aspire Dashboard
 
-The Aspire dashboard opens automatically at `https://localhost:17183` and provides:
+The Aspire dashboard URL is displayed in the terminal when the AppHost starts. It provides:
 - Real-time view of all services and their status
 - Centralized logs from all services
 - Distributed traces

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ dotnet run --project src/NuGetTrends.AppHost
 
 This starts PostgreSQL, RabbitMQ, ClickHouse, the Angular SPA, Web API, and Scheduler - all with a single command.
 
-The **Aspire Dashboard** opens at `https://localhost:17183` showing all services, logs, and traces.
+The **Aspire Dashboard** URL is shown in the terminal output, providing a view of all services, logs, and traces.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed setup instructions.
 


### PR DESCRIPTION
## Summary
- Replaced hardcoded `https://localhost:17183` with a reference to the terminal output in both README.md and CONTRIBUTING.md
- The Aspire Dashboard port is dynamically assigned, allowing concurrent instances without port conflicts

## Test plan
- [ ] Verify README.md and CONTRIBUTING.md render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)