### PR TITLE
fix: improve TrendChart readability and interaction

### DIFF
--- a/src/NuGetTrends.Web.Client/Shared/TrendChart.razor
+++ b/src/NuGetTrends.Web.Client/Shared/TrendChart.razor
@@ -92,8 +92,17 @@
         // Adapt marker size to the data density
         var showMarkers = SearchPeriod <= 12;
 
-        // Set x-axis min so the axis spans the full requested period
-        var xMin = new DateTimeOffset(DateTime.UtcNow.AddMonths(-SearchPeriod)).ToUnixTimeMilliseconds();
+        // Set x-axis min so the axis spans the full requested period,
+        // but extend further if the data starts before the period boundary.
+        var periodStart = DateTime.UtcNow.AddMonths(-SearchPeriod);
+        var earliestWeek = Datasets
+            .SelectMany(p => p.Downloads)
+            .Where(d => d.Count.HasValue)
+            .Select(d => d.Week)
+            .DefaultIfEmpty(periodStart)
+            .Min();
+        var xMinDate = earliestWeek < periodStart ? earliestWeek : periodStart;
+        var xMin = new DateTimeOffset(xMinDate).ToUnixTimeMilliseconds();
 
         return new ApexChartOptions<DownloadDataPoint>
         {
@@ -163,10 +172,11 @@
                             FontSize = "13px",
                         },
                         Formatter = @"function(val) {
+                            if (val === null || val === undefined || isNaN(val)) return '';
                             if (val >= 1e9) return (val / 1e9).toFixed(1).replace(/\.0$/, '') + 'B';
                             if (val >= 1e6) return (val / 1e6).toFixed(1).replace(/\.0$/, '') + 'M';
                             if (val >= 1e3) return (val / 1e3).toFixed(1).replace(/\.0$/, '') + 'K';
-                            return val;
+                            return val.toLocaleString();
                         }",
                     },
                 },


### PR DESCRIPTION
## Summary
- Disable zoom (scroll + buttons) to prevent accidental zooming on the packages chart
- Set X-axis `Min` to span the full search period so ApexCharts auto-selects appropriate label granularity (years for long ranges, months/days for short)
- Abbreviate Y-axis values (K/M/B) while keeping exact numbers in hover tooltip
- Increase axis label font size to 13px (matching Frameworks chart from #442)
- Explicitly set `Shared = true` / `Intersect = false` on tooltip to show all series on hover
- Always show full date (`dd MMM yyyy`) in tooltip regardless of time range

## Test plan
- [ ] On `/packages` with a single package at "All time" (169 months): X-axis shows yearly labels ("2018", "2019"...), Y-axis shows abbreviated values ("20M", "40M"...)
- [ ] At "3 months": X-axis shows day/month labels ("20 Nov", "Dec 2025"...), markers visible
- [ ] Hovering shows tooltip with full date and exact number (e.g. "03 Feb 2020 — Sentry: 1,365,619")
- [ ] No zoom on scroll wheel, no zoom buttons in toolbar
- [ ] With multiple packages: tooltip shows all series at hovered X position
- [ ] Font size is readable on both axes

🤖 Generated with [Claude Code](https://claude.com/claude-code)