### PR TITLE
docs(footer): link authors to personal websites

### DIFF
--- a/src/NuGetTrends.Web.Client/Shared/Footer.razor
+++ b/src/NuGetTrends.Web.Client/Shared/Footer.razor
@@ -31,7 +31,7 @@
             </div>
         </div>
         <p class="has-text-centered has-text-white-bis">
-            Brought to you by <a href="https://github.com/bruno-garcia">Bruno Garcia</a> &amp; <a href="https://github.com/joaopgrassi">João Grassi</a>
+            Brought to you by <a href="https://brunogarcia.com/">Bruno Garcia</a> &amp; <a href="https://joaograssi.com/">João Grassi</a>
         </p>
         <p class="has-text-centered has-text-grey-light sentry-sponsor">
             <a href="https://sentry.io/welcome/" target="_blank" rel="noopener" title="Application Monitoring by Sentry">


### PR DESCRIPTION
Update footer links for Bruno Garcia and João Grassi from their GitHub profiles to their personal websites (brunogarcia.com and joaograssi.com).